### PR TITLE
ASM-2896 do not block for RAID background initialization

### DIFF
--- a/lib/puppet/provider/idrac.rb
+++ b/lib/puppet/provider/idrac.rb
@@ -261,7 +261,7 @@ class Puppet::Provider::Idrac <  Puppet::Provider
     response = view_disks
     response.xpath('//DCIM_VirtualDiskView').each do |disk|
       current_op = disk.at_xpath('//OperationName').content
-      if(current_op != 'None')
+      unless current_op =~ /None|Background/
         fqdd = disk.at_xpath('FQDD').content
         percent = disk.at_xpath('OperationPercentComplete').content
         Puppet.info("Virtual disk #{fqdd} is currently performing operation #{current_op} at #{percent} percent completion. Waiting...")


### PR DESCRIPTION
After creation of a new virtual disk, a RAID background
initialization job will start after a few minutes to write parity
data. That operation can take hours to days to complete. The new
idrac code to monitor the virtual disk operations was blocking
waiting for that operation to complete. The virtual disk should
be usable while that operation is running, so this commit changes
the polling code to ignore the background initialization job.