### PR TITLE
ASM-2949 use ASM:WsMan for better error handling

### DIFF
--- a/lib/puppet/provider/checkjdstatus.rb
+++ b/lib/puppet/provider/checkjdstatus.rb
@@ -11,28 +11,20 @@ class Puppet::Provider::Checkjdstatus <  Puppet::Provider
   end
 
   def checkjdstatus
-    #Get the job status
-    #response = `wsman get "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_LifecycleJob?InstanceID=#{@instanceid}" -h #{@ip} -V -v -c dummy.cert -P 443 -u #{@username} -p #{@password} -j utf-8 -y basic`
-	  response = executecmd
-    Puppet.info "#{response}"
-    xmldoc = Document.new(response)
-    jdnode = XPath.first(xmldoc, "//n1:JobStatus")
-    jdmsg = XPath.first(xmldoc, "//n1:Message")
-    tempjdnode = jdnode
-    if jdmsg.to_s =~ /Completed with Errors/i || jdmsg.to_s =~ /Completed with errors/i || jdnode.to_s =~ /Completed with Errors/i || jdnode.to_s =~ /Completed with errors/i
-      return "Failed"
-    end
-
-    if tempjdnode.to_s == ""
+    require 'asm/wsman'
+    endpoint = {:host => @ip, :user => @username, :password => @password}
+    schema = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_LifecycleJob?InstanceID=#{@instanceid}"
+    job_status, job_message = ASM::WsMan.invoke(endpoint, 'get', schema,
+                                                :logger => Puppet,
+                                                :selector => ["//n1:JobStatus", "//n1:Message"])
+    if job_status =~ /completed with errors/i || job_message =~ /completed with errors/i
+      'Failed'
+    elsif job_status.nil? || job_status.empty?
       raise "Job ID not created"
+    else
+      job_status
     end
-    jdstatus=jdnode.text
-    return jdstatus
   end
 
-  def executecmd
-    resp = `wsman get "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_LifecycleJob?InstanceID=#{@instanceid}" -h #{@ip} -V -v -c dummy.cert -P 443 -u #{@username} -p #{@password} -j utf-8 -y basic`
-    return resp
-  end
 end
 

--- a/lib/puppet/provider/checklcstatus.rb
+++ b/lib/puppet/provider/checklcstatus.rb
@@ -2,7 +2,6 @@ require 'rexml/document'
 require 'asm/wsman'
 
 include REXML
-require 'pty'
 
 class Puppet::Provider::Checklcstatus < Puppet::Provider
   def initialize (ip, username, password)

--- a/spec/unit/puppet/provider/checkjdstatus_spec.rb
+++ b/spec/unit/puppet/provider/checkjdstatus_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'puppet/provider/checkjdstatus'
 require 'yaml'
 require 'rspec/expectations'
+require 'asm/wsman'
 
 describe Puppet::Provider::Checkjdstatus do
 	
@@ -90,12 +91,14 @@ END
 	end
 	context "when checking lc status" do
 		it "should job check status job id"  do
-		    @fixture.should_receive(:executecmd).once.and_return(@respjdstatus)
+			status = 'Completed'
+			message = 'Successfully exported system configuration XML file.'
+			ASM::WsMan.should_receive(:invoke).once.and_return([status, message])
 			status = @fixture.checkjdstatus
 			status.should == "Completed"
 		end
 		it "should fail if invalid job id passed" do
-			@fixture.should_receive(:executecmd).once.and_return(@failedresp)
+			ASM::WsMan.should_receive(:invoke).once.and_return([nil, nil])
 			expect {@fixture.checkjdstatus}.to raise_error("Job ID not created")
 		end
 	end

--- a/spec/unit/puppet/provider/exporttemplatexml_spec.rb
+++ b/spec/unit/puppet/provider/exporttemplatexml_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 require 'puppet/provider/exporttemplatexml'
 require 'yaml'
 require 'rspec/expectations'
+require 'asm/wsman'
+require 'nokogiri'
+
 describe Puppet::Provider::Exporttemplatexml do
 	let(:test_config_dir){ File.join(Dir.pwd, "spec", "fixtures") }
 	before(:each) do
@@ -19,59 +22,6 @@ describe Puppet::Provider::Exporttemplatexml do
         }
 		@fixture=Puppet::Provider::Exporttemplatexml.new(@idrac_attrib['ip'],@idrac_attrib['username'],@idrac_attrib['password'],@idrac_attrib,File.join(test_config_dir, "mock_nfs"))
 		@fixture.stub(:initialize).and_return("")
-		@commandoutput = <<END
-		<?xml version="1.0" encoding="UTF-8"?>
-<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:n1="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_LCService" xmlns:wsman="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">
-  <s:Header>
-    <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
-    <wsa:Action>http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_LCService/ExportSystemConfigurationResponse</wsa:Action>
-    <wsa:RelatesTo>uuid:eea1d72e-efcd-1fcd-8002-9f3392565000</wsa:RelatesTo>
-    <wsa:MessageID>uuid:7803a3f2-efde-1fde-81d7-502ed9ddf95c</wsa:MessageID>
-  </s:Header>
-  <s:Body>
-    <n1:ExportSystemConfiguration_OUTPUT>
-      <n1:Job>
-        <wsa:EndpointReference>
-          <wsa:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:Address>
-          <wsa:ReferenceParameters>
-            <wsman:ResourceURI>http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_LifeCycleJob</wsman:ResourceURI>
-            <wsman:SelectorSet>
-              <wsman:Selector Name="InstanceID">JID_896386820311</wsman:Selector>
-              <wsman:Selector Name="__cimnamespace">root/dcim</wsman:Selector>
-            </wsman:SelectorSet>
-          </wsa:ReferenceParameters>
-        </wsa:EndpointReference>
-      </n1:Job>
-      <n1:ReturnValue>4096</n1:ReturnValue>
-    </n1:ExportSystemConfiguration_OUTPUT>
-  </s:Body>
-</s:Envelope>
-END
-	@failedcommandoutput = <<END
-	<?xml version="1.0" encoding="UTF-8"?>
-<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsman="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd">
-  <s:Header>
-    <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
-    <wsa:Action>http://schemas.dmtf.org/wbem/wsman/1/wsman/fault</wsa:Action>
-    <wsa:RelatesTo>uuid:da4b90fc-efcd-1fcd-8002-9f3392565000</wsa:RelatesTo>
-    <wsa:MessageID>uuid:6fb8c614-efde-1fde-8083-562ed9ddf95c</wsa:MessageID>
-  </s:Header>
-  <s:Body>
-    <s:Fault>
-      <s:Code>
-        <s:Value>s:Receiver</s:Value>
-        <s:Subcode>
-          <s:Value>wsman:TimedOut</s:Value>
-        </s:Subcode>
-      </s:Code>
-      <s:Reason>
-        <s:Text xml:lang="en">The operation has timed out.</s:Text>
-      </s:Reason>
-    </s:Fault>
-  </s:Body>
-</s:Envelope>
-
-END
 	end
 	
 	context " instance validation " do
@@ -94,28 +44,28 @@ END
 	end
 	context "when exporting template" do
 		it "should get Job id for Export template xml"  do
-                        @fixture.should_receive(:commandexe).once.and_return(@commandoutput)
+      ASM::WsMan.should_receive(:invoke).once.and_return('JID_896386820311')
 
-			Puppet::Provider::Checkjdstatus.any_instance.stub(:checkjdstatus) do
+      Puppet::Provider::Checkjdstatus.any_instance.stub(:checkjdstatus) do
 				xml_doc = Nokogiri::XML::Builder.new do |xml|
 					xml.send(:"SystemConfiguration")
 				end
 				File.open(File.join(test_config_dir, "mock_nfs", "EXPORT_exported.xml"), 'w+') { |file| file.write(xml_doc.to_xml(:indent => 2)) }
-				"Completed"	
-			end
-			jobid = @fixture.exporttemplatexml
-			jobid.should == "JID_896386820311"
-			File.exist?(File.join(test_config_dir, "EXPORT_exported.xml")).should == true
+				"Completed"
+      end
+      jobid = @fixture.exporttemplatexml
+      jobid.should == "JID_896386820311"
+      File.exist?(File.join(test_config_dir, "EXPORT_exported.xml")).should == true
 			File.exist?(File.join(test_config_dir, "mock_nfs", "EXPORT_exported.xml")).should_not == true
 
 		end
-		it "should not get Job it if export template fail" do
-			 @fixture.should_receive(:commandexe).once.and_return(@failedcommandoutput)
-			 expect{ @fixture.exporttemplatexml}.to raise_error("Job ID not created")
-		     
-		end
 
-		after(:all) do
+    it "should not get Job it if export template fail" do
+      ASM::WsMan.should_receive(:invoke).once.and_return(nil)
+      expect { @fixture.exporttemplatexml }.to raise_error("Job ID not created")
+    end
+
+    after(:all) do
 			FileUtils.rm(File.join(test_config_dir, "EXPORT_exported.xml"))
 		end
 	end


### PR DESCRIPTION
Migrate checkjdstatus and exporttemplatexml to use ASM::WsMan for
ws-man invocations. Previously they were directly invoking the
wsman CLI with little error handling. This change fixes problems
such as when iDrac sporadically returns erroneous 401
authentication failed errors.