### PR TITLE
Changed importsystemconfiguration workflow to help reliability/stability

### DIFF
--- a/lib/puppet/provider/exporttemplatexml.rb
+++ b/lib/puppet/provider/exporttemplatexml.rb
@@ -4,13 +4,13 @@ require 'puppet/provider/checkjdstatus'
 include REXML
 
 class Puppet::Provider::Exporttemplatexml <  Puppet::Provider
-  def initialize (ip,username,password, resource, nfswritepath='/var/nfs')
+  def initialize (ip,username,password, resource, nfswritepath='/var/nfs', name_postfix='original')
     @ip = ip
     @username = username
     @password = password
     @resource = resource
     @nfswritepath = nfswritepath
-    @file_name = File.basename(@resource[:configxmlfilename], ".xml")+"_exported.xml"
+    @file_name = File.basename(@resource[:configxmlfilename], ".xml")+ "_#{name_postfix}.xml"
   end
 
   def exporttemplatexml
@@ -21,7 +21,7 @@ class Puppet::Provider::Exporttemplatexml <  Puppet::Provider
     jid = ASM::WsMan.invoke(endpoint, method, schema,
                             :logger => Puppet,
                             :selector => '//wsman:Selector Name="InstanceID"',
-                            :props => {'IPAddress' => @resource['nfsipaddress'],
+                            :props => {'IPAddress' => @resource[:nfsipaddress],
                                        'ShareName' => @nfswritepath,
                                        'ShareType' => 0,
                                        'FileName' => @file_name, })

--- a/lib/puppet/provider/importsystemconfiguration/default.rb
+++ b/lib/puppet/provider/importsystemconfiguration/default.rb
@@ -11,11 +11,32 @@ Puppet::Type.type(:importsystemconfiguration).provide(
   desc "Dell idrac provider for import system configuration."
 
   def create
+    instance_id = setup_idrac
+    wait_for_import(instance_id)
+    #Need to export again so we have a template with updated values from the setup step before.
+    exporttemplate('base')
+    instance_id = importtemplate
+    wait_for_import(instance_id)
+    disks_ready = false
+    Puppet.info('Checking for virtual disks to be out of any running operation...')
+    for j in 0..30
+      disks_ready = virtual_disks_ready?
+      if(disks_ready)
+        break
+      else
+        sleep 60
+      end
+    end
+    if !disks_ready
+      raise 'Virtual disk(s) currrently busy.'
+    end
+  end
+
+  def wait_for_import(instance_id)
     import_try = 1
-    instanceid = importtemplate
-    Puppet.info "Instance id #{instanceid}"
+    Puppet.info "Instance id #{instance_id}"
     for i in 0..30
-      response = checkjobstatus instanceid
+      response = checkjobstatus instance_id
       Puppet.info "JD status : #{response}"
       if response  == "Completed"
         Puppet.info "Import System Configuration is completed."
@@ -35,6 +56,7 @@ Puppet::Type.type(:importsystemconfiguration).provide(
     end
     # For config XML case, its observed that we have to invoke the import
     # operation twice as a workaround.
+    # This may no longer be necessary with the initial "setup" import workflow.
     if response == "Completed" and !@resource[:config_xml].nil?
       Puppet.info('For referenced server configuration, need to perform the configuration XML twice')
       sleep(60)
@@ -42,19 +64,6 @@ Puppet::Type.type(:importsystemconfiguration).provide(
     end
     if response != "Completed"
       raise "Import System Configuration is still running."
-    end
-    disks_ready = false
-    Puppet.info('Checking for virtual disks to be out of any running operation...')
-    for j in 0..30
-      disks_ready = virtual_disks_ready?
-      if(disks_ready)
-        break
-      else
-        sleep 60
-      end
-    end
-    if !disks_ready
-      raise 'Virtual disk(s) currrently busy.'
     end
   end
   
@@ -66,11 +75,11 @@ Puppet::Type.type(:importsystemconfiguration).provide(
     lcstatus
     reboot if !skip_reset
     lcstatus
-    exporttemplate
+    exporttemplate('base')
     
     synced = !resource[:force_reboot] && config_in_sync?
     if synced
-      Puppet.debug("Configuration are already in synced, skipping the import operation")
+      Puppet.debug("Configuration is already in sync. Skipping the import operation")
       return true
     end
         

--- a/templates/preset-config.erb
+++ b/templates/preset-config.erb
@@ -1,0 +1,21 @@
+<SystemConfiguration Model="" ServiceTag="<%= @resource[:servicetag] %>" TimeStamp="">
+<% if !bios_presets.empty? -%>
+  <Component FQDD="BIOS.Setup.1-1">
+<% if bios_presets['IntegratedRaid'] -%>
+    <Attribute Name="IntegratedRaid"><%= bios_presets['IntegratedRaid'] %></Attribute>
+<% end -%>
+<% if bios_presets['InternalSdCard'] -%>
+    <Attribute Name="InternalSdCard"><%= bios_presets['InternalSdCard'] %></Attribute>
+<% end -%>
+  </Component>
+<% end -%>
+<% if !nic_presets.empty? -%>
+<% nic_presets.each do |nic_name, attr_values| -%>
+  <Component FQDD="<%= nic_name %>">
+<% attr_values.each do |attr_name, attr_value| -%>
+      <Attribute Name="<%= attr_name %>"><%= attr_value %></Attribute>
+<% end -%>
+  </Component>
+<% end -%>
+<% end -%>
+</SystemConfiguration>


### PR DESCRIPTION
There will now be 4 files from the exports/imports.  
  * <servicetag>_original.xml which contains the target server's configuration before any changes are made
  * <servicetag>_preset.xml which contains basic attributes that we send in first to "preset" the idrac to be in a state that's easy for us to use.  This includes setting up partitioning, setting up boot protocol, enabling raid, enabling SD card.
  * <servicetag>_base.xml which contains the configuration that will be used as the reference for the config we send to the server
  * <servicetag>.xml which contains the system configuration we import to the target server.

The main part is the _preset.xml, which should allow us to enable/disable what needs to be set up on the idrac in order for the import to work as smoothly as possible.