### PR TITLE
ASM-2857 Reset virtual mac addresses during deployment

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -517,6 +517,14 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
                 end
               end
 
+              # Reset virtual mac addresses by default
+              if changes['NicMode'] == 'Enabled'
+                changes['VirtMacAddr'] = '00:00:00:00:00:00'
+              end
+              if changes['iScsiOffloadMode'] == 'Enabled'
+                changes['VirtIscsiMacAddr'] = '00:00:00:00:00:00'
+              end
+
               changes['MinBandwidth'] = partition.minimum
               changes['MaxBandwidth'] = partition.maximum
               if(partition_no == 1)


### PR DESCRIPTION
Should help brown-field cases where the server has virtual mac
addresses set. Specifically this fixes a case we saw where they
had a server with duplicate virtual mac addresses.