### PR TITLE
skip background configuration in virtual_disks_ready?

### DIFF
--- a/lib/puppet/provider/idrac.rb
+++ b/lib/puppet/provider/idrac.rb
@@ -261,14 +261,14 @@ class Puppet::Provider::Idrac <  Puppet::Provider
     response = view_disks
     response.xpath('//DCIM_VirtualDiskView').each do |disk|
       current_op = disk.at_xpath('//OperationName').content
-      if(current_op != 'None')
+      unless current_op =~ /None|Background/
         fqdd = disk.at_xpath('FQDD').content
         percent = disk.at_xpath('OperationPercentComplete').content
         Puppet.info("Virtual disk #{fqdd} is currently performing operation #{current_op} at #{percent} percent completion. Waiting...")
         return false
       end
     end
-    return true
+    true
   end
 
   def view_disks


### PR DESCRIPTION
This change was made in 8.1 branch but never backported to 8.0