### PR TITLE
import config should no longer rely on /var/nfs open permissions

### DIFF
--- a/lib/puppet/provider/exporttemplatexml.rb
+++ b/lib/puppet/provider/exporttemplatexml.rb
@@ -6,12 +6,12 @@ include REXML
 
 class Puppet::Provider::Exporttemplatexml <  Puppet::Provider
 
-  def initialize (ip,username,password, resource, nfswritepath='/var/nfs', name_postfix='original')
+  def initialize (ip,username,password, resource, name_postfix='original')
     @ip = ip
     @username = username
     @password = password
     @resource = resource
-    @nfswritepath = nfswritepath
+    @nfswritepath = resource[:nfssharepath]
     @file_name = File.basename(@resource[:configxmlfilename], ".xml")+ "_#{name_postfix}.xml"
   end
 
@@ -24,38 +24,39 @@ class Puppet::Provider::Exporttemplatexml <  Puppet::Provider
              'FileName' => @file_name, }
     job_id = Puppet::Idrac::Util.wsman_system_config_action(:export, props)
     Puppet.debug("ExportSystemConfiguration job id: #{job_id}")
-    move_config_xml(job_id)
+    wait_for_job(job_id)
+    process_xml
     job_id
   end
 
-  #TODO:  This needs to be changed to not use /var/nfs, and instead write to /var/nfs/idrac_config_xml
-  #Just puts the xml in the idrac_config_xml folder (for use with importsystemconfiguration later), writing to /var/nfs due to nfs write permissions
-  def move_config_xml(instanceid)
+  def wait_for_job(instanceid)
     obj = Puppet::Provider::Checkjdstatus.new(@ip,@username,@password,instanceid)
-    for i in 0..30
+    for i in 0..10
       response = obj.checkjdstatus
       if response  == "Completed"
         Puppet.info "Export System Configuration is completed."
-        file_path = File.join(@nfswritepath, @file_name)
-        #Need to remove this section because of potentially sensitive data
-        xml = Nokogiri::XML(File.read(file_path))
-        xml.xpath("//Component[not(contains(@FQDD, 'NIC.') or contains(@FQDD, 'BIOS.') or contains(@FQDD, 'RAID.') or contains(@FQDD, 'LifecycleController.'))]").remove
-        #The remove above leaves many empty lines in the xml.  Just remove all the text() at the top level to keep file clean
-        xml.xpath('/SystemConfiguration/text()').remove
-        File.open(file_path, 'w+') { |file| file.write(xml.root.to_xml(:indent => 2)) }
-        FileUtils.mv(file_path, @resource[:nfssharepath])
         break
       else
         if response  == "Failed"
           raise "Job Failed."
         else
-          Puppet.info "Job is running, wait for 1 minute."
-          sleep 5
+          Puppet.info "Export job is still running, waiting..."
+          sleep 15
         end
       end
     end
     if response != "Completed"
       raise "Export System Configuration has not completed."
     end
+  end
+
+  def process_xml
+    file_path = File.join(@nfswritepath, @file_name)
+    #Need to remove this section because of potentially sensitive data
+    xml = Nokogiri::XML(File.read(file_path))
+    xml.xpath("//Component[not(contains(@FQDD, 'NIC.') or contains(@FQDD, 'BIOS.') or contains(@FQDD, 'RAID.') or contains(@FQDD, 'LifecycleController.'))]").remove
+    #The remove above leaves many empty lines in the xml.  Just remove all the text() at the top level to keep file clean
+    xml.xpath('/SystemConfiguration/text()').remove
+    File.open(file_path, 'w+') { |file| file.write(xml.root.to_xml(:indent => 2)) }
   end
 end

--- a/lib/puppet/provider/idrac.rb
+++ b/lib/puppet/provider/idrac.rb
@@ -174,13 +174,11 @@ class Puppet::Provider::Idrac <  Puppet::Provider
   end
 
   def execute_export_config(postfix='original')
-    #TODO:  remove /var/nfs and prefer to use resource[:nfssharepath]
     obj = Puppet::Provider::Exporttemplatexml.new(
         transport[:host],
         transport[:user],
         transport[:password],
         resource,
-        '/var/nfs',
         postfix
     )
     obj.exporttemplatexml

--- a/spec/unit/puppet/provider/exporttemplatexml_spec.rb
+++ b/spec/unit/puppet/provider/exporttemplatexml_spec.rb
@@ -7,7 +7,7 @@ require 'nokogiri'
 require 'puppet/idrac/util'
 
 describe Puppet::Provider::Exporttemplatexml do
-	let(:test_config_dir){ File.join(Dir.pwd, "spec", "fixtures") }
+	let(:test_config_dir){ File.join(Dir.pwd, "spec", "fixtures", "mock_nfs") }
 	before(:each) do
 		Puppet::Module.stub(:find).with("idrac").and_return(test_config_dir)
 		@idrac_attrib = {
@@ -21,7 +21,7 @@ describe Puppet::Provider::Exporttemplatexml do
           :servicetag => 'EXPORT',
           :nfssharepath => test_config_dir
         }
-		@fixture=Puppet::Provider::Exporttemplatexml.new(@idrac_attrib[:ip],@idrac_attrib[:username],@idrac_attrib[:password], @idrac_attrib,File.join(test_config_dir, "mock_nfs"))
+		@fixture=Puppet::Provider::Exporttemplatexml.new(@idrac_attrib[:ip],@idrac_attrib[:username],@idrac_attrib[:password], @idrac_attrib)
 		@fixture.stub(:initialize).and_return("")
 	end
 
@@ -37,7 +37,7 @@ describe Puppet::Provider::Exporttemplatexml do
 			@fixture.instance_variable_get(:@password).should eql(@idrac_attrib[:password])
 			#@fixture.instance_variable_get(:@file_name).should eql(@idrac_attrib[:configxmlfilename])
 			#@fixture.instance_variable_get(:@nfsipaddress).should eql(@idrac_attrib[:nfsipaddress])
-			@fixture.instance_variable_get(:@nfswritepath).should eql(File.join(test_config_dir, "mock_nfs"))
+			@fixture.instance_variable_get(:@nfswritepath).should eql(test_config_dir)
 		end
 		it "should have method " do
 			@fixture.class.instance_method(:exporttemplatexml).should_not == nil
@@ -52,13 +52,12 @@ describe Puppet::Provider::Exporttemplatexml do
 				xml_doc = Nokogiri::XML::Builder.new do |xml|
 					xml.send(:"SystemConfiguration")
 				end
-				File.open(File.join(test_config_dir, "mock_nfs", "EXPORT_original.xml"), 'w+') { |file| file.write(xml_doc.to_xml(:indent => 2)) }
+				File.open(File.join(test_config_dir, "EXPORT_original.xml"), 'w+') { |file| file.write(xml_doc.to_xml(:indent => 2)) }
 				"Completed"
 			end
 			jobid = @fixture.exporttemplatexml
 			jobid.should == "JID_896386820311"
 			File.exist?(File.join(test_config_dir, "EXPORT_original.xml")).should == true
-			File.exist?(File.join(test_config_dir, "mock_nfs", "EXPORT_original.xml")).should_not == true
 
 		end
 		it "should not get Job it if export template fail" do

--- a/tests/disablenpar.pp
+++ b/tests/disablenpar.pp
@@ -6,5 +6,5 @@ importnparsetting {
     dracusername => 'root',
     dracpassword => 'calvin',
     nfsipaddress => '172.28.15.192',
-    nfssharepath => '/var/nfs',
+    nfssharepath => '/var/nfs/idrac_config_xml',
 }

--- a/tests/enablenpar.pp
+++ b/tests/enablenpar.pp
@@ -6,5 +6,5 @@ importnparsetting {
     dracusername => 'root',
     dracpassword => 'calvin',
     nfsipaddress => '172.28.15.192',
-    nfssharepath => '/var/nfs',
+    nfssharepath => '/var/nfs/idrac_config_xml',
 }

--- a/tests/exportsystemconfiguration.pp
+++ b/tests/exportsystemconfiguration.pp
@@ -4,6 +4,6 @@ exportsystemconfiguration { 'exportsystemconfiguration':
   dracpassword => 'calvin',
   configxmlfilename => 'testconfig.xml',
   nfsipaddress => '172.28.10.189',
-  nfssharepath => '/var/nfs',
+  nfssharepath => '/var/nfs/idrac_config_xml',
 }
 

--- a/tests/importbiosconfiguration.pp
+++ b/tests/importbiosconfiguration.pp
@@ -3,7 +3,7 @@ importbiosconfiguration { 'importbiosconfiguration':
   dracusername => 'root',
   dracpassword => 'calvin',
   nfsipaddress => '172.28.10.189',
-  nfssharepath => '/var/nfs',
+  nfssharepath => '/var/nfs/idrac_config_xml',
   biosbootseq => 'HardDisk.List.1-1'
 }
 

--- a/tests/importraidconfiguration.pp
+++ b/tests/importraidconfiguration.pp
@@ -4,7 +4,7 @@ importraidconfiguration { 'importraidconfiguration':
   dracpassword => 'calvin',
   raidtype => '0',
   nfsipaddress => '172.28.10.189',
-  nfssharepath => '/var/nfs',
+  nfssharepath => '/var/nfs/idrac_config_xml',
   disk => 'Disk.Bay.0:Enclosure.Internal.0-1:RAID.Integrated.1-1,Disk.Bay.1:Enclosure.Internal.0-1:RAID.Integrated.1-1'
 }
 

--- a/tests/importsystemconfiguration.pp
+++ b/tests/importsystemconfiguration.pp
@@ -4,6 +4,6 @@ importsystemconfiguration { 'importsystemconfiguration':
   dracpassword => 'calvin',
   configxmlfilename => 'testconfig.xml',
   nfsipaddress => '172.28.10.189',
-  nfssharepath => '/var/nfs',
+  nfssharepath => '/var/nfs/idrac_config_xml',
 }
 


### PR DESCRIPTION
This change is for 8.2, and should probably wait until then unless needed beforehand for whatever reasons.