### PR TITLE
Clear job queue improvements

### DIFF
--- a/spec/unit/puppet/provider/importtemplatexml_spec.rb
+++ b/spec/unit/puppet/provider/importtemplatexml_spec.rb
@@ -303,6 +303,8 @@ end
       ASM::NetworkConfiguration.stub(:new).and_return(net_config)
       ASM::WsMan.stub(:invoke).and_return(@view_disk_xml)
       Puppet::Provider::Importtemplatexml.any_instance.stub(:get_raid_config_changes).and_return({})
+      @fixture.stub(:find_target_bios_setting).and_return("value")
+      @fixture.stub(:find_target_bios_setting).with('InvalidAttribute').and_return(nil)
       #The xml that @fixture will read (FOOTAG_original) will have the InvalidAttribute attribute. It should not exist after munging.
       xml = @fixture.munge_config_xml
       xml.at_xpath("//Component[@FQDD='BIOS.Setup.1-1']//Attribute[@Name='InvalidAttribute']").should == nil


### PR DESCRIPTION
    Job queue will now be cleared before we do a reboot of the server instead of after.  We will also query the LC to check that the job queue is also empty before allowing it to go on

I also fixed the tests.  yay.