### PR TITLE
ASM-3529 Added  new import to fix iscsi/fcoe offload not being set

### DIFF
--- a/lib/puppet/idrac/util.rb
+++ b/lib/puppet/idrac/util.rb
@@ -6,6 +6,7 @@ require 'pty'
 module Puppet
   module Idrac
     module Util
+      class ConfigError < Exception; end
       def self.get_transport
         require 'asm/device_management'
         @transport ||= begin

--- a/lib/puppet/provider/checkjdstatus.rb
+++ b/lib/puppet/provider/checkjdstatus.rb
@@ -2,6 +2,7 @@ require 'rexml/document'
 
 include REXML
 
+# TODO: This class doesn't really need to exist.  Could be shoved into a common method instead, maybe in Puppet::Idrac::Util
 class Puppet::Provider::Checkjdstatus <  Puppet::Provider
   def initialize (ip,username,password,instanceid)
     @ip = ip

--- a/lib/puppet/provider/idrac.rb
+++ b/lib/puppet/provider/idrac.rb
@@ -43,17 +43,17 @@ class Puppet::Provider::Idrac <  Puppet::Provider
   end
 
   #this could probably be more "integrated" with importtemplatexml's munge_config_xml with some reasonable changes to that function
-  def config_in_sync?
+  def config_in_sync?(export_postfix='original')
     in_sync = true
     import_obj = Puppet::Provider::Importtemplatexml.new(
       transport[:host],
       transport[:user],
       transport[:password],
       resource,
-      'original'
+      export_postfix
     )
     changes = import_obj.get_config_changes
-    exported_config = File.basename(resource[:configxmlfilename], ".xml")+"_original.xml"
+    exported_config = File.basename(resource[:configxmlfilename], ".xml")+"_#{export_postfix}.xml"
     config_xml_path = File.join(resource[:nfssharepath], exported_config)
     f = File.open(config_xml_path)
     xml_doc = Nokogiri::XML(f.read) do |config|
@@ -193,30 +193,6 @@ class Puppet::Provider::Idrac <  Puppet::Provider
 
   def transport
     @transport ||= Puppet::Idrac::Util.get_transport
-  end
-
-  def importtemplate
-    Puppet::Idrac::Util.wait_for_running_jobs
-    obj = Puppet::Provider::Importtemplatexml.new(
-      transport[:host],
-      transport[:user],
-      transport[:password],
-      resource,
-      'base'
-    )
-    obj.importtemplatexml
-  end
-
-  def setup_idrac
-    Puppet::Idrac::Util.wait_for_running_jobs
-    obj = Puppet::Provider::Importtemplatexml.new(
-        transport[:host],
-        transport[:user],
-        transport[:password],
-        resource,
-        'original'
-    )
-    obj.setup_idrac
   end
 
   def exporttemplate(postfix='original')

--- a/spec/unit/puppet/provider/importtemplatexml_spec.rb
+++ b/spec/unit/puppet/provider/importtemplatexml_spec.rb
@@ -158,7 +158,7 @@ end
 	end
 	context "when exporting template" do
 		it "should get Job id for Export template xml"  do
-			@fixture.should_receive(:executeimportcmd).once.and_return('JID_896466295795')
+			@fixture.should_receive(:execute_import).once.and_return('JID_896466295795')
 			@fixture.stub(:munge_config_xml)
 			jobid = @fixture.importtemplatexml
 			jobid.should == "JID_896466295795"


### PR DESCRIPTION
There were also some changes to improve the code a bit 
1) We now wait for import inside of importtemplatexml.rb rather than having the object pass back the job id and waiting outside.  This is just to "compartmentalize" the import process so the code is kept more "contained"
2) Wrapped the different import calls with the retry code and cleaned that up a bit.
3) Various improvements to the setup process.  Now, we should be checking now if anything needs to change before we actually do the import.

IMPORTANT: Should be merged with https://github.com/dell-asm/asm/pull/234