### PR TITLE
ASM-4331 use local ip for import / export by default

### DIFF
--- a/lib/puppet/provider/exporttemplatexml.rb
+++ b/lib/puppet/provider/exporttemplatexml.rb
@@ -16,7 +16,8 @@ class Puppet::Provider::Exporttemplatexml <  Puppet::Provider
   end
 
   def exporttemplatexml
-    props = {'IPAddress' => @resource[:nfsipaddress],
+    require 'asm/util'
+    props = {'IPAddress' => @resource[:nfsipaddress] || ASM::Util.get_preferred_ip(@ip),
              'ShareName' => @nfswritepath,
              'ShareType' => 0,
              'FileName' => @file_name, }

--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -15,8 +15,6 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
     @username = username
     @password = password
     @configxmlfilename = resource[:configxmlfilename]
-    @nfsipaddress = resource[:nfsipaddress]
-    @nfssharepath = resource[:nfssharepath]
     @resource = resource
     @bios_settings = resource[:bios_settings]
     @network_config_data = resource[:network_config]
@@ -144,7 +142,12 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
   end
 
   def execute_import(file_name=@resource['configxmlfilename'])
-    props = {'IPAddress'=> @resource['nfsipaddress'], 'ShareName'=> @resource['nfssharepath'], 'ShareType'=> '0', 'FileName'=> file_name, 'ShutdownType'=> '1'}
+    require 'asm/util'
+    props = {'IPAddress' => @resource[:nfsipaddress] || ASM::Util.get_preferred_ip(@ip),
+             'ShareName' => @resource['nfssharepath'],
+             'ShareType' => '0',
+             'FileName' => file_name,
+             'ShutdownType' => '1'}
     job_id = Puppet::Idrac::Util.wsman_system_config_action(:import, props)
     wait_for_import(job_id)
   end


### PR DESCRIPTION
If nfsipaddress is not specified in the importsystemconfiguration
resource, use the current IP by default. This allows the same
configuration to function properly on any worker node.