### PR TITLE
ASM-3406 remove asm_decrypt password encryption

### DIFF
--- a/lib/puppet/provider/importraidconfiguration/default.rb
+++ b/lib/puppet/provider/importraidconfiguration/default.rb
@@ -95,7 +95,6 @@ Puppet::Type.type(:importraidconfiguration).provide(
     @ip       = transport[:host]
     @username = transport[:user]
     @password = transport[:password]
-    @password = URI.decode(asm_decrypt(@password))
 
     response = `wsman invoke -a CreateVirtualDisk http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_RAIDService?SystemCreationClassName=DCIM_ComputerSystem,CreationClassName=DCIM_RAIDService,SystemName=DCIM:ComputerSystem,Name=DCIM:RAIDService -h #{@ip} -V -v -c dummy.cert -P 443 -u #{@username} -p #{@password} -J #{raidconfigurationfile} -j utf-8 -y basic`
   end
@@ -118,7 +117,6 @@ Puppet::Type.type(:importraidconfiguration).provide(
     @ip       = transport[:host]
     @username = transport[:user]
     @password = transport[:password]
-    @password = URI.decode(asm_decrypt(@password))
     #Reset Configuration
     resetfilepath = File.join(Pathname.new(__FILE__).parent.parent.parent.parent.parent, 'files/defaultxmls/resetconfig.xml')
 


### PR DESCRIPTION
An encrypted device password was passed to the asm-deployer device
management service and written to the device configuration file
url. That password has been deprecated and all puppet-layer code
should use the credential_id argument in preference to that.