### PR TITLE
ASM-4431 HyperV iSCSI failure when 57800 is skipped by ASM

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -646,6 +646,8 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
         partitioned = interface['partitioned']
         interface.partitions.each do |partition|
           fqdd = partition.fqdd
+          # Skipping the FQDDs where MAC address information is not avaialble.
+          next if partition.mac_address.nil?
           #
           # SET UP NIC IN CASE INTERFACE IS BEING PARTITIONED, equivalent to the enable_npar parameter
           #


### PR DESCRIPTION
Skipping the import configuration operation on the FQDDs for which MAC address information is not accessible. We are skipping the MAC address information for NIC 3 and 4 for 57800. This change will help in skipping the configuration for these NICS. The attributes set for other NPAR NIC configuration is not applicable to 1GB NICs from 57800 NIC Card