### PR TITLE
ASM-3297 Fixed an issue where SD was not being disabled for BFS

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -310,7 +310,7 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
 
   def munge_bfs_bootdevice(changes)
     Puppet.debug("configuring the bfs boot device")
-    changes['partial'].deep_merge!({'BIOS.Setup.1-1' => { 'InternalSDCard' => "Off",  'IntegratedRaid' => 'Disabled'} })
+    changes['partial'].deep_merge!({'BIOS.Setup.1-1' => { 'InternalSdCard' => "Off",  'IntegratedRaid' => 'Disabled'} })
   end
 
   def munge_network_configuration(network_configuration, changes, target_boot)


### PR DESCRIPTION
Incorrect capitalization caused the attribute to be trashed before sending the import (which would have failed if we weren't trashing BIOS attributes that don't exist on the server)