### PR TITLE
ASM-5753 BIOS VT settings

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -168,12 +168,11 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
       changes['partial'].deep_merge!('BIOS.Setup.1-1' => {'HddSeq' => 'Disk.SDInternal.1-1'})
     end
     #If we have target boot device = NONE or NONE_WITH_RAID, we don't want to edit boot settings.
-    #If installing an OS, we need ProcVirtualization=Enabled, and BootMode=Bios
+    #If installing an OS, we need BootMode=Bios
     if @boot_device =~ /^NONE/i
       changes['remove']['attributes']['BIOS.Setup.1-1'] ||= []
       changes['remove']['attributes']['BIOS.Setup.1-1'] << 'BiosBootSeq'
     else
-      changes['partial']['BIOS.Setup.1-1']['ProcVirtualization'] = 'Enabled'
       changes['partial']['BIOS.Setup.1-1']['BootMode'] = 'Bios'
     end
     changes


### PR DESCRIPTION
Don't hardcode BIOS VT settings to enabled when specifying target
boot device