### PR TITLE
ASM-5767 Import config fails with Idrac timeout

### DIFF
--- a/lib/puppet/idrac/util.rb
+++ b/lib/puppet/idrac/util.rb
@@ -151,7 +151,7 @@ module Puppet
             end
           end
         end
-        wait_for_idrac
+        wait_for_idrac(360)
       end
 
       def self.wait_for_idrac (timeout = 180, state = 0)
@@ -212,3 +212,4 @@ module Puppet
     end
   end
 end
+


### PR DESCRIPTION
If we are resetting the idrac. We need to wait longer before timing out
when checking for the idrac to become available again