### PR TITLE
ASM-6335 Power server off after system config applied

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -54,7 +54,8 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
              'ShareName' => @resource['nfssharepath'],
              'ShareType' => '0',
              'FileName' => file_name,
-             'ShutdownType' => '0'}
+             'ShutdownType' => '0',      # graceful shutdown
+             'EndHostPowerState' => '0'} # final power state is off
     forced_shutdown = false
     begin
       job_id = Puppet::Idrac::Util.wsman_system_config_action(:import, props)


### PR DESCRIPTION
This prevents the server from booting into who-knows-what is installed
on it after the configuration is complete. Server should be manually
powered on separately when needed.