### PR TITLE
Revert "ASM-6335 Power server off after system config applied"

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -54,8 +54,7 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
              'ShareName' => @resource['nfssharepath'],
              'ShareType' => '0',
              'FileName' => file_name,
-             'ShutdownType' => '0',      # graceful shutdown
-             'EndHostPowerState' => '0'} # final power state is off
+             'ShutdownType' => '0'}
     forced_shutdown = false
     begin
       job_id = Puppet::Idrac::Util.wsman_system_config_action(:import, props)


### PR DESCRIPTION
Reverts dell-asm/dell-idrac#200

This change seems to be causing an increased number of failures to set PXE in the boot order. The FQDDs in BiosBootSeq seem to be changing when the server first turns on after the ImportSystemConfiguration job was run, even though LC team reports that CSIOR is stell run with EndHostPowerState = 0.

I.e. after running an ImportSystemConfiguration job but before turning the server on I got:

    [root@dellasm idrac_config_xml]# wsman_shell.rb --server 172.17.1.223
    [1] pry(#<ASM::WsMan>)> boot_source_settings.map { |e| [e[:current_assigned_sequence], e[:instance_id]] }
    => [["0",
      "IPL:BIOS.Setup.1-1#BootSeq#HardDisk.List.1-1#c9203080df84781e2ca3d512883dee6f"],
     ["1",
      "IPL:BIOS.Setup.1-1#BootSeq#NIC.Integrated.1-1-1#b358f1564c3350889a9ec123cb23ad56"],
     ["2",
      "IPL:BIOS.Setup.1-1#BootSeq#NIC.Integrated.1-2-1#a9e6ef3b3531098d24fcf6d1be2bddd6"],
     ["3",
      "IPL:BIOS.Setup.1-1#BootSeq#Unknown.Unknown.3-1#49c33a66a875b23ddeed96cb6df3d17b"],
     ["4",
      "IPL:BIOS.Setup.1-1#BootSeq#Unknown.Unknown.4-1#1918bb9468ef2afe7ff908904b577095"],
     ["0",
      "BCV:BIOS.Setup.1-1#HddSeq#RAID.Integrated.1-1#1371dc7ee8f6b710c6111ca11410999e"]]

After turning the server on and letting it run CSIOR I got:

    [2] pry(#<ASM::WsMan>)> boot_source_settings.map { |e| [e[:current_assigned_sequence], e[:instance_id]] }
    => [["0",
      "IPL:BIOS.Setup.1-1#BootSeq#HardDisk.List.1-1#c9203080df84781e2ca3d512883dee6f"],
     ["1",
      "IPL:BIOS.Setup.1-1#BootSeq#NIC.Integrated.1-1-1#b358f1564c3350889a9ec123cb23ad56"],
     ["2",
      "IPL:BIOS.Setup.1-1#BootSeq#NIC.Integrated.1-2-1#a9e6ef3b3531098d24fcf6d1be2bddd6"],
     ["3",
      "IPL:BIOS.Setup.1-1#BootSeq#Unknown.Unknown.4-1#a19ac45217ac67c25cef20a352dfb4d3"],
     ["4",
      "IPL:BIOS.Setup.1-1#BootSeq#Unknown.Unknown.5-1#8073d5bef01666786c3749c91636f96d"],
     ["0",
      "BCV:BIOS.Setup.1-1#HddSeq#RAID.Integrated.1-1#1371dc7ee8f6b710c6111ca11410999e"]]
