### PR TITLE
ASM-5482 removing the asm-deployer dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,18 @@ gem 'activesupport'
 gem 'nokogiri', '1.5.10'
 gem 'dell-asm-util', :git => 'https://github.com/dell-asm/dell-asm-util.git', :branch => 'master'
 
+# Add gems necessary to run facter on Windows
+platforms :mswin, :mingw do
+  gem 'sys-admin'
+  gem 'win32-process'
+  gem 'win32-dir'
+  gem 'win32-security'
+  gem 'win32-service'
+  gem 'win32-taskscheduler'
+  gem 'windows-pr'
+end
+
 group :development, :test do
-  gem 'asm-deployer', :git => 'git@github.com:dell-asm/asm-deployer.git'
   gem 'rake'
   gem 'rspec'
   gem 'puppetlabs_spec_helper'

--- a/lib/puppet/idrac/util.rb
+++ b/lib/puppet/idrac/util.rb
@@ -1,7 +1,7 @@
 require 'rexml/document'
 
 include REXML
-require 'pty'
+
 
 module Puppet
   module Idrac
@@ -10,12 +10,13 @@ module Puppet
     class ShutdownError < Exception; end
     class PendingChangesError < Exception; end
     module Util
-      # FIXME: asm/device_management is dependent on asm-deployer, which should be eliminated as a dependency for this module
+
       def self.get_transport
-        require 'asm/device_management'
-        @transport ||= begin
-          ASM::DeviceManagement.parse_device_config(Puppet[:certname])
-        end
+        @transport
+      end
+
+      def self.transport=(transport)
+        @transport = transport
       end
 
       def self.view_disks(type=:virtual)

--- a/lib/puppet/provider/idrac.rb
+++ b/lib/puppet/provider/idrac.rb
@@ -11,6 +11,11 @@ require 'net/ssh'
 require 'puppet/util/warnings'
 require 'fileutils'
 
+require 'pathname' # workaround not necessary in newer versions of Puppet
+mod = Puppet::Module.find('transport', Puppet[:environment].to_s)
+require File.join mod.path, 'lib/puppet_x/puppetlabs/transport'
+require 'puppet_x/puppetlabs/transport/idrac'
+
 class Puppet::Provider::Idrac <  Puppet::Provider
   def exists?
     wait_for_lc_ready
@@ -160,7 +165,11 @@ class Puppet::Provider::Idrac <  Puppet::Provider
   end
 
   def transport
-    @transport ||= Puppet::Idrac::Util.get_transport
+    @transport ||= begin
+     transport=PuppetX::Puppetlabs::Transport.retrieve(:resource_ref => resource[:transport], :catalog => resource.catalog, :provider => 'idrac')
+     Puppet::Idrac::Util.transport = transport.endpoint
+     transport.endpoint
+    end
   end
 
   def exporttemplate(postfix='original')

--- a/lib/puppet/provider/idrac_fw_installfromuri/wsman.rb
+++ b/lib/puppet/provider/idrac_fw_installfromuri/wsman.rb
@@ -156,10 +156,6 @@ Puppet::Type.type(:idrac_fw_installfromuri).provide(
     end
   end
 
-  def transport
-    @transport ||= Puppet::Idrac::Util.get_transport()
-  end
-
   def run_wsman(cmd)
     wait_for_lc_ready
     sleeptime = 30

--- a/lib/puppet/provider/idrac_fw_update/wsman.rb
+++ b/lib/puppet/provider/idrac_fw_update/wsman.rb
@@ -2,7 +2,8 @@ require 'puppet/idrac/util'
 require 'nokogiri'
 require 'active_support'
 
-Puppet::Type.type(:idrac_fw_update).provide(:wsman) do
+Puppet::Type.type(:idrac_fw_update).provide(:wsman,
+                                            :parent => Puppet::Provider::Idrac) do
 
   def exists?
     @share = resource[:path].split('/')[0..-2].join('/')
@@ -28,10 +29,6 @@ Puppet::Type.type(:idrac_fw_update).provide(:wsman) do
     else
       raise Puppet::Error, doc.xpath('//n1:Message')
     end
-  end
-
-  def transport
-    @transport ||= Puppet::Idrac::Util.get_transport()
   end
 
   def run_wsman(cmd)

--- a/lib/puppet/provider/idrac_racadm.rb
+++ b/lib/puppet/provider/idrac_racadm.rb
@@ -1,11 +1,11 @@
 begin
   require 'puppet_x/puppetlabs/transport'
-  require 'puppet_x/puppetlabs/transport/idrac'
+  require 'puppet_x/puppetlabs/transport/racadm'
 rescue LoadError
   require 'pathname' # WORK_AROUND #14073 and #7788
   mod = Puppet::Module.find('transport', Puppet[:environment].to_s)
   require File.join mod.path, 'lib/puppet_x/puppetlabs/transport'
-  require File.join mod.path, 'lib/puppet_x/puppetlabs/transport/idrac'
+  require File.join mod.path, 'lib/puppet_x/puppetlabs/transport/racadm'
 end
 
 class Puppet::Provider::IdracRacadm <  Puppet::Provider
@@ -23,7 +23,7 @@ class Puppet::Provider::IdracRacadm <  Puppet::Provider
   end
 
   def client
-    @transport ||= PuppetX::Puppetlabs::Transport.retrieve(:resource_ref => resource[:transport], :catalog => resource.catalog, :provider => 'idrac')
+    @transport ||= PuppetX::Puppetlabs::Transport.retrieve(:resource_ref => resource[:transport], :catalog => resource.catalog, :provider => 'racadm')
     @transport.ssh
   end
 

--- a/lib/puppet/provider/powerstate/default.rb
+++ b/lib/puppet/provider/powerstate/default.rb
@@ -1,10 +1,11 @@
 provider_path = Pathname.new(__FILE__).parent.parent
 require 'rexml/document'
-
 include REXML
 require 'puppet/idrac/util'
+require File.join(provider_path, 'idrac')
 
-Puppet::Type.type(:powerstate).provide(:powerstate) do
+Puppet::Type.type(:powerstate).provide(:powerstate,
+                                       :parent => Puppet::Provider::Idrac) do
   desc "Dell idrac provider for import system configuration."
   def exists?
     if checkpowerstate != :on
@@ -17,10 +18,6 @@ Puppet::Type.type(:powerstate).provide(:powerstate) do
 
   def create
     ensure_on
-  end
-
-  def transport
-    @transport ||= Puppet::Idrac::Util.get_transport()
   end
 
   def ensure_on

--- a/lib/puppet_x/puppetlabs/transport/idrac.rb
+++ b/lib/puppet_x/puppetlabs/transport/idrac.rb
@@ -1,9 +1,6 @@
-require 'net/ssh'
 module PuppetX::Puppetlabs::Transport
   class Idrac
-    attr_accessor :ssh
     attr_reader :name
-
     def initialize(opts)
       @name    = opts[:name]
       options  = opts[:options] || {}
@@ -11,29 +8,15 @@ module PuppetX::Puppetlabs::Transport
       @options[:host]     = opts[:server]
       @options[:user]     = opts[:username]
       @options[:password] = opts[:password]
-      Puppet.debug("#{self.class} initializing connection to: #{@options[:host]}")
     end
 
     def connect
-      i = 0
-      begin
-        port = @options[:port] ? @options[:port] : 22
-        @ssh = Net::SSH.start(@options[:host], @options[:user], {:port => port, :password => @options[:password]})
-      rescue => e
-        i += 1
-         if i < 4
-           Puppet.debug("PuppetX::Puppetlabs::Transport::Idrac failed to connect. retrying in 10 seconds...")
-           sleep 10
-           retry
-         else
-          raise e
-         end
-      end
+      #satifies transport interface requirements
     end
 
-    def close
-      Puppet.debug("#{self.class} closing connection to: #{@options[:host]}")
-      @ssh.close if @ssh
+    def endpoint
+      @options
     end
+
   end
 end

--- a/lib/puppet_x/puppetlabs/transport/racadm.rb
+++ b/lib/puppet_x/puppetlabs/transport/racadm.rb
@@ -1,0 +1,40 @@
+require 'net/ssh'
+module PuppetX::Puppetlabs::Transport
+  class Racadm
+    attr_accessor :ssh
+    attr_reader :name
+
+    def initialize(opts)
+      @name    = opts[:name]
+      options  = opts[:options] || {}
+      @options = options.inject({}){|h, (k, v)| h[k.to_sym] = v; h}
+      @options[:host]     = opts[:server]
+      @options[:user]     = opts[:username]
+      @options[:password] = opts[:password]
+      Puppet.debug("#{self.class} initializing connection to: #{@options[:host]}")
+    end
+
+    def connect
+      i = 0
+      begin
+        port = @options[:port] ? @options[:port] : 22
+        @ssh = Net::SSH.start(@options[:host], @options[:user], {:port => port, :password => @options[:password]})
+      rescue => e
+        i += 1
+         if i < 4
+           Puppet.debug("PuppetX::Puppetlabs::Transport::Idrac failed to connect. retrying in 10 seconds...")
+           sleep 10
+           retry
+         else
+          raise e
+         end
+      end
+    end
+
+    def close
+      Puppet.debug("#{self.class} closing connection to: #{@options[:host]}")
+      @ssh.close if @ssh
+    end
+
+  end
+end

--- a/spec/unit/puppet/provider/importtemplatexml_spec.rb
+++ b/spec/unit/puppet/provider/importtemplatexml_spec.rb
@@ -22,7 +22,7 @@ describe Puppet::Provider::Importtemplatexml do
   end
 
   before(:each) do
-    @test_config_dir = URI(File.join(Dir.pwd, "spec", "fixtures"))
+    @test_config_dir = URI( File.expand_path("../../../../fixtures", __FILE__))
     @view_disk_xml = File.read(@test_config_dir.path + '/disks.xml')
     Puppet::Module.stub(:find).with("idrac").and_return(@test_config_dir)
     @mock_net_config_data =
@@ -140,7 +140,7 @@ describe Puppet::Provider::Importtemplatexml do
         :enable_npar => 'true',
         :target_boot_device => 'HD',
         :servicetag => 'FOOTAG',
-        :nfssharepath => @test_config_dir.to_s,
+        :nfssharepath => @test_config_dir.path.to_s,
         :network_config => @mock_net_config_data,
         :raid_configuration => @mock_raid_config,
         :bios_settings => {'InternalSdCard' => 'Enabled'}
@@ -355,7 +355,7 @@ describe Puppet::Provider::Importtemplatexml do
       @network_configuration = JSON.parse(File.read(@test_config_dir.path + '/network_configuration.json'))['networkConfiguration']
       #ASM::NetworkConfiguration.any_instance.stub(:new).and_return(ASM::NetworkConfiguration.new(@network_configuration))
       #ASM::NetworkConfiguration.any_instance.stub(:add_nics!).and_return(nil)
-      @test_config_dir = URI(File.join(Dir.pwd, "spec", "fixtures"))
+      @test_config_dir = URI( File.expand_path("../../../../fixtures", __FILE__))
       Puppet::Module.stub(:find).with("idrac").and_return(@test_config_dir)
       #Puppet::Provider::Importtemplatexml.any_instance.stub(:process_nics).and_return({"partial" => {"NIC.Integrated.1-1-1" => {"IntegratedRaid"=>"Disabled"}}})
       @fixture.resource[:target_boot_device] = 'iSCSI'


### PR DESCRIPTION
Changing where the idrac module gets user,password,ip_address info for the transport method so that we don't depend on asm-deployer.
This needs dell-asm/asm#290