### PR TITLE
ASM-6719 Import configuration operation failing for VSAN with SD card in case HBA mode is not already set

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -460,8 +460,7 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
             raid_configuration = {}
             disk_types.keys.each do |disk|
               controller = disk.split(':').last
-              raid_configuration[controller] ||= []
-              raid_configuration[controller] << disk
+              raid_configuration[controller][:hotspares] << disk
             end
             Puppet.debug("Inside VSAN RAID Configuration: #{raid_configuration}")
           elsif !(unprocessed['virtualDisks'].empty? && unprocessed['externalVirtualDisks'].empty?)

--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -464,7 +464,7 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
               raid_configuration[controller] << disk
             end
             Puppet.debug("Inside VSAN RAID Configuration: #{raid_configuration}")
-          elsif unprocessed['virtualDisks'].empty? && unprocessed['externalVirtualDisks'].empty?
+          elsif !(unprocessed['virtualDisks'].empty? && unprocessed['externalVirtualDisks'].empty?)
             (unprocessed['virtualDisks'] + unprocessed['externalVirtualDisks']).each do |config|
               type = disk_types[config['physicalDisks'].first]
               #Just check first disk in the list to get what type of virtual disk it is

--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -456,7 +456,15 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
             disk_types[fqdd] = type
           end
           raid_configuration = Hash.new { |h, k| h[k] = {:virtual_disks => [], :hotspares => []} }
-          unless unprocessed['virtualDisks'].empty? && unprocessed['externalVirtualDisks'].empty?
+          if unprocessed.nil? && @boot_device.match(/VSAN/i)
+            raid_configuration = {}
+            disk_types.keys.each do |disk|
+              controller = disk.split(':').last
+              raid_configuration[controller] ||= []
+              raid_configuration[controller] << disk
+            end
+            Puppet.debug("Inside VSAN RAID Configuration: #{raid_configuration}")
+          elsif unprocessed['virtualDisks'].empty? && unprocessed['externalVirtualDisks'].empty?
             (unprocessed['virtualDisks'] + unprocessed['externalVirtualDisks']).each do |config|
               type = disk_types[config['physicalDisks'].first]
               #Just check first disk in the list to get what type of virtual disk it is

--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -457,7 +457,6 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
           end
           raid_configuration = Hash.new { |h, k| h[k] = {:virtual_disks => [], :hotspares => []} }
           if unprocessed.nil? && @boot_device.match(/VSAN/i)
-            raid_configuration = {}
             disk_types.keys.each do |disk|
               controller = disk.split(':').last
               raid_configuration[controller][:hotspares] << disk


### PR DESCRIPTION
Import configuration operation failing for VSAN with SD card in case HBA mode is not already set. This loop never got tested as we were using the servers which were atleast once configured to be used as VSAN node.
This bug got introduced while addressing the code comments. After addressing the code comments this part was not tested.