### PR TITLE
ASM-6720 Config XML import operation fails to set HBA mode when Virtual Disks are present

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'activesupport'
 gem 'nokogiri', '1.5.10'
+gem 'rbvmomi'
 gem 'dell-asm-util', :git => 'https://github.com/dell-asm/dell-asm-util.git', :branch => 'master'
 
 group :development, :test do

--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -497,6 +497,8 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
       if @boot_device =~ /VSAN/i
         if target_current_xml.to_s.match(/="CurrentControllerMode">RAID/)
           changes['whole'][raid_configuration.keys.first] = { 'CurrentControllerMode' => "HBA"}
+          # Need to remove Virtual Disks when we move Controller from RAID to HBA mode.
+          raid_configuration.keys.each{|controller| changes['whole'][controller] = { 'RAIDresetConfig' => "True" } }
         end
       elsif @boot_device =~ /WITH_RAID|HD/i
         changes['partial'] = {'BIOS.Setup.1-1'=> {'HddSeq' => raid_configuration.keys.first}} if @boot_device =~ /HD/i


### PR DESCRIPTION
Included "RAIDresetconfig" attribute with the RAID controller while moving the Controller from RAID to HBA mode. This will ensure all the Virtual Disks are removed before the HBA mode is configured.
In case there is any Virtual Disk on the RAID controller, then HBA mode cannot be set.

Also, then Controller is already in HBA mode then RAIDresetconfig is not allowed by iDRAC that why we are limiting the RAIDresetconfig attribute only in case we are moving controller from RAID to HBA mode.