### PR TITLE
ASM-6781 Fix transport in idrac_fw_installfromuri

### DIFF
--- a/lib/puppet/provider/idrac_fw_installfromuri/wsman.rb
+++ b/lib/puppet/provider/idrac_fw_installfromuri/wsman.rb
@@ -27,6 +27,7 @@ Puppet::Type.type(:idrac_fw_installfromuri).provide(
 
 
   def exists?
+    transport # Force initialization, Puppet::Idrac::Util depends on it
     @force_restart = resource[:force_restart]
     @firmwares = ASM::Util.asm_json_array(resource[:idrac_firmware])
     false
@@ -143,10 +144,6 @@ Puppet::Type.type(:idrac_fw_installfromuri).provide(
       Puppet.info("Failed firmware jobs: #{failures}")
       raise Puppet::Error, "Firmware update failed in the lifecycle controller.  Please refer to LifeCycle job logs"
     end
-  end
-
-  def transport
-    @transport ||= Puppet::Idrac::Util.get_transport()
   end
 
   def wsman_client


### PR DESCRIPTION
8.2 changes that were made to use the ASM::WsMan library in
idrac_fw_installfromuri to fix password-handling problems weren't
compatible with 8.3 changes to use a transport resource.