### PR TITLE
ASM-6558 Interoperability with wsmancli 2.6

### DIFF
--- a/lib/puppet/idrac/util.rb
+++ b/lib/puppet/idrac/util.rb
@@ -99,7 +99,7 @@ module Puppet
         Puppet.debug("Clearing Job Queue")
         tries = 1
         begin
-          schema = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_JobService?CreationClassName=\"DCIM_JobService\",SystemName=\"Idrac\",Name=\"JobService\",SystemCreationClassName=\"DCIM_ComputerSystem\""
+          schema = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_JobService?CreationClassName=\"DCIM_JobService\"&SystemName=\"Idrac\"&Name=\"JobService\"&SystemCreationClassName=\"DCIM_ComputerSystem\""
           options = {:props=>{"JobID"=> "JID_CLEARALL#{"_FORCE" if force}"}, :selector => ["//n1:ReturnValue", "//n1:Message"], :logger => Puppet}
           response_id, message = ASM::WsMan.invoke(get_transport, "DeleteJobQueue", schema, options)
           if response_id == '0'
@@ -195,7 +195,7 @@ module Puppet
 
       def self.wsman_system_config_action(type, props={})
         require 'asm/wsman'
-        schema ='http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_LCService?SystemCreationClassName="DCIM_ComputerSystem",CreationClassName="DCIM_LCService",SystemName="DCIM:ComputerSystem",Name="DCIM:LCService"'
+        schema ='http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_LCService?SystemCreationClassName="DCIM_ComputerSystem"&CreationClassName="DCIM_LCService"&SystemName="DCIM:ComputerSystem"&Name="DCIM:LCService"'
         options = {:props=>props, :logger => Puppet}
         job_id = ''
         action = "#{type.capitalize}SystemConfiguration"

--- a/lib/puppet/provider/checklcstatus.rb
+++ b/lib/puppet/provider/checklcstatus.rb
@@ -17,7 +17,7 @@ class Puppet::Provider::Checklcstatus < Puppet::Provider
   def executelccmd
     endpoint = {:host => @ip, :user => @username, :password => @password}
     ASM::WsMan.invoke(endpoint, 'GetRemoteServicesAPIStatus',
-                      'http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_LCService?SystemCreationClassName="DCIM_ComputerSystem",CreationClassName="DCIM_LCService",SystemName="DCIM:ComputerSystem",Name="DCIM:LCService"',
+                      'http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_LCService?SystemCreationClassName="DCIM_ComputerSystem"&CreationClassName="DCIM_LCService"&SystemName="DCIM:ComputerSystem"&Name="DCIM:LCService"',
                       :selector => '//n1:LCStatus',
                       :logger => Puppet)
   end

--- a/lib/puppet/provider/idrac_fw_installfromuri/wsman.rb
+++ b/lib/puppet/provider/idrac_fw_installfromuri/wsman.rb
@@ -152,7 +152,7 @@ Puppet::Type.type(:idrac_fw_installfromuri).provide(
 
   def install_from_uri(config_file)
     config_file_path = config_file.path
-    schema = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService,SystemCreationClassName=DCIM_ComputerSystem,SystemName=IDRAC:ID,Name=SoftwareUpdate"
+    schema = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService&SystemCreationClassName=DCIM_ComputerSystem&SystemName=IDRAC:ID&Name=SoftwareUpdate"
     resp = wsman_client.invoke("InstallFromURI", schema, :input_file => config_file_path)
     if resp[:return_value] == '4096'
       job_id = resp[:job]
@@ -214,7 +214,7 @@ EOF
   end
 
   def create_reboot_job(reboot_file)
-    url = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService,SystemCreationClassName=DCIM_ComputerSystem,SystemName=IDRAC:ID,Name=SoftwareUpdate"
+    url = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService&SystemCreationClassName=DCIM_ComputerSystem&SystemName=IDRAC:ID&Name=SoftwareUpdate"
     Puppet.debug("Creating Reboot Job")
     resp = wsman_client.invoke("CreateRebootJob", url, :input_file => reboot_file.path)
     if resp[:return_value] == '4096'
@@ -229,7 +229,7 @@ EOF
   end
 
   def setup_job_queue(job_queue_config_file)
-    url = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_JobService?CreationClassName=\"DCIM_JobService\",SystemName=\"Idrac\",Name=\"JobService\",SystemCreationClassName=\"DCIM_ComputerSystem\" -N root/dcim"
+    url = "http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_JobService?CreationClassName=\"DCIM_JobService\"&SystemName=\"Idrac\"&Name=\"JobService\"&SystemCreationClassName=\"DCIM_ComputerSystem\" -N root/dcim"
     Puppet.debug("Setting up Job Queue")
     4.times do |t|
       resp = wsman_client.invoke("SetupJobQueue", url, :input_file => job_queue_config_file.path)

--- a/lib/puppet/provider/idrac_fw_update/wsman.rb
+++ b/lib/puppet/provider/idrac_fw_update/wsman.rb
@@ -20,7 +20,7 @@ Puppet::Type.type(:idrac_fw_update).provide(:wsman,
 
 
   def check_for_update
-    wsman_cmd =  "wsman invoke -a 'InstallFromRepository' http://schemas.dell.com/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService+SystemCreationClassName=DCIM_ComputerSystem+SystemName=IDRAC:ID+Name=SoftwareUpdate -h #{transport[:host]} -P 443 -u #{transport[:user]} -p #{transport[:password]} -c Dummy -y basic -V -v -k \"ipaddress=#{@asm_hostname}\" -k \"sharename=#{@share}\" -k \"sharetype=0\" -k \"RebootNeeded=#{@restart}\" -k \"ApplyUpdate=0\" -k \"CatalogName=#{@catalog_name}\""
+    wsman_cmd =  "wsman invoke -a 'InstallFromRepository' http://schemas.dell.com/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService&SystemCreationClassName=DCIM_ComputerSystem&SystemName=IDRAC:ID&Name=SoftwareUpdate -h #{transport[:host]} -P 443 -u #{transport[:user]} -p #{transport[:password]} -c Dummy -y basic -V -v -k \"ipaddress=#{@asm_hostname}\" -k \"sharename=#{@share}\" -k \"sharetype=0\" -k \"RebootNeeded=#{@restart}\" -k \"ApplyUpdate=0\" -k \"CatalogName=#{@catalog_name}\""
     resp = run_wsman(wsman_cmd)
     Puppet.debug(resp)
     doc = Nokogiri::XML(resp)
@@ -64,7 +64,7 @@ Puppet::Type.type(:idrac_fw_update).provide(:wsman,
 
   def parse_for_updates
     #Returns true when there is no updates to be installed
-    wsman_cmd = "wsman invoke -a \"GetRepoBasedUpdateList\" http://schemas.dell.com/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService+SystemCreationClassName=DCIM_ComputerSystem+SystemName=IDRAC:ID+Name=SoftwareUpdate -h #{transport[:host]} -u #{transport[:user]} -p #{transport[:password]} -P 443 -c Dummy -y basic -V -v"
+    wsman_cmd = "wsman invoke -a \"GetRepoBasedUpdateList\" http://schemas.dell.com/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService&SystemCreationClassName=DCIM_ComputerSystem&SystemName=IDRAC:ID&Name=SoftwareUpdate -h #{transport[:host]} -u #{transport[:user]} -p #{transport[:password]} -P 443 -c Dummy -y basic -V -v"
     Puppet.debug("WSMAN invoking: GetRepoBasedUpdateList")
     sleep 30
     resp = run_wsman(wsman_cmd)
@@ -112,7 +112,7 @@ Puppet::Type.type(:idrac_fw_update).provide(:wsman,
 
   def create
     Puppet.debug('ABOUT TO APPLY FIRMWARE UPDATES')
-    wsman_cmd =  "wsman invoke -a 'InstallFromRepository' http://schemas.dell.com/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService+SystemCreationClassName=DCIM_ComputerSystem+SystemName=IDRAC:ID+Name=SoftwareUpdate -h #{transport[:host]} -P 443 -u #{transport[:user]} -p #{transport[:password]} -c Dummy -y basic -V -v -k \"ipaddress=#{@asm_hostname}\" -k \"sharename=#{@share}\" -k \"sharetype=0\" -k \"RebootNeeded=#{@restart}\" -k \"ApplyUpdate=1\" -k \"CatalogName=#{@catalog_name}\""
+    wsman_cmd =  "wsman invoke -a 'InstallFromRepository' http://schemas.dell.com/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService&SystemCreationClassName=DCIM_ComputerSystem&SystemName=IDRAC:ID&Name=SoftwareUpdate -h #{transport[:host]} -P 443 -u #{transport[:user]} -p #{transport[:password]} -c Dummy -y basic -V -v -k \"ipaddress=#{@asm_hostname}\" -k \"sharename=#{@share}\" -k \"sharetype=0\" -k \"RebootNeeded=#{@restart}\" -k \"ApplyUpdate=1\" -k \"CatalogName=#{@catalog_name}\""
     Puppet.debug("WSMAN invoking: InstallFromRepository")
     resp = run_wsman(wsman_cmd)
     Puppet.debug("WSMAN RESPONSE: #{resp}")
@@ -213,7 +213,7 @@ Puppet::Type.type(:idrac_fw_update).provide(:wsman,
  
   def clear_job_queue
     Puppet.debug("Clearing Job Queue")
-    wsman_cmd = "wsman invoke -a \"DeleteJobQueue\" http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_JobService?CreationClassName=\"DCIM_JobService\",SystemName=\"Idrac\",Name=\"JobService\",SystemCreationClassName=\"DCIM_ComputerSystem\" -N root/dcim -u #{transport[:user]} -p #{transport[:password]} -h #{transport[:host]} -P 443 -v -j utf-8 -y basic -o -m 256 -c Dummy -V  -k \"JobID=JID_CLEARALL\" "
+    wsman_cmd = "wsman invoke -a \"DeleteJobQueue\" http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_JobService?CreationClassName=\"DCIM_JobService\"&SystemName=\"Idrac\"&Name=\"JobService\"&SystemCreationClassName=\"DCIM_ComputerSystem\" -N root/dcim -u #{transport[:user]} -p #{transport[:password]} -h #{transport[:host]} -P 443 -v -j utf-8 -y basic -o -m 256 -c Dummy -V  -k \"JobID=JID_CLEARALL\" "
     resp = run_wsman(wsman_cmd)
     doc = Nokogiri::XML(resp)
     if doc.xpath('//n1:MessageID').text == 'SUP020'
@@ -225,7 +225,7 @@ Puppet::Type.type(:idrac_fw_update).provide(:wsman,
   
   def get_api_status
     Puppet.debug("Checking API Status")
-    wsman_cmd = "wsman invoke -a GetRemoteServicesAPIStatus http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_LCService?SystemCreationClassName=\"DCIM_ComputerSystem\",CreationClassName=\"DCIM_LCService\",SystemName=\"DCIM:ComputerSystem\",Name=\"DCIM:LCService\" -u #{transport[:user]} -p #{transport[:password]} -h #{transport[:host]} -P 443 -v -y basic -c Dummy -V"
+    wsman_cmd = "wsman invoke -a GetRemoteServicesAPIStatus http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_LCService?SystemCreationClassName=\"DCIM_ComputerSystem\"&CreationClassName=\"DCIM_LCService\"&SystemName=\"DCIM:ComputerSystem\"&Name=\"DCIM:LCService\" -u #{transport[:user]} -p #{transport[:password]} -h #{transport[:host]} -P 443 -v -y basic -c Dummy -V"
     resp = %x[ #{wsman_cmd} ]
     doc = Nokogiri::XML(resp)
     if doc.xpath('//n1:LCStatus').text == "0"

--- a/lib/puppet/provider/powerstate/default.rb
+++ b/lib/puppet/provider/powerstate/default.rb
@@ -35,7 +35,7 @@ Puppet::Type.type(:powerstate).provide(:powerstate,
     endpoint = {:host => transport[:host], :user => transport[:user], :password => transport[:password]}
     options = {'RequestedState' => '2'}
     ASM::WsMan.invoke(endpoint, 'RequestStateChange',
-    'http://schemas.dell.com/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_ComputerSystem?CreationClassName="DCIM_ComputerSystem",Name="srv:system"',
+    'http://schemas.dell.com/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_ComputerSystem?CreationClassName="DCIM_ComputerSystem"&Name="srv:system"',
     :selector => '//n1:ReturnValue',
     :logger => Puppet,
     :props => options)

--- a/lib/puppet/provider/reboot.rb
+++ b/lib/puppet/provider/reboot.rb
@@ -28,8 +28,8 @@ class Puppet::Provider::Reboot <  Puppet::Provider
   def rebootidrac
     # Create the reboot job
     puts "Rebooting server #{@ip}"
-    #response = `wsman invoke -a CreateRebootJob http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService,SystemCreationClassName=DCIM_ComputerSystem,SystemName=IDRAC:ID,Name=SoftwareUpdate -h "#{@ip}" -V -v -c dummy.cert -P 443 -u "#{@username}" -p "#{@password}" -J #{@rebootfilepath} -j utf-8 -y basic -k "RebootJobType=2" -k "ShutdownType=1"`
-    response = `wsman invoke -a CreateTargetedConfigJob http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_BIOSService?SystemCreationClassName=DCIM_ComputerSystem,CreationClassName=DCIM_BIOSService,SystemName=DCIM:ComputerSystem,Name=DCIM:BIOSService -h "#{@ip}" -V -v -c dummy.cert -P 443 -u "#{@username}" -p "#{@password}" -J #{@rebootfilepath} -j utf-8 -y basic`
+    #response = `wsman invoke -a CreateRebootJob http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_SoftwareInstallationService?CreationClassName=DCIM_SoftwareInstallationService&SystemCreationClassName=DCIM_ComputerSystem&SystemName=IDRAC:ID&Name=SoftwareUpdate -h "#{@ip}" -V -v -c dummy.cert -P 443 -u "#{@username}" -p "#{@password}" -J #{@rebootfilepath} -j utf-8 -y basic -k "RebootJobType=2" -k "ShutdownType=1"`
+    response = `wsman invoke -a CreateTargetedConfigJob http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_BIOSService?SystemCreationClassName=DCIM_ComputerSystem&CreationClassName=DCIM_BIOSService&SystemName=DCIM:ComputerSystem&Name=DCIM:BIOSService -h "#{@ip}" -V -v -c dummy.cert -P 443 -u "#{@username}" -p "#{@password}" -J #{@rebootfilepath} -j utf-8 -y basic`
     xmldoc = Document.new(response)
     instancenode = XPath.first(xmldoc, '//wsman:Selector Name="InstanceID"')
     tempinstancenode = instancenode


### PR DESCRIPTION
Update ws-man URLs to use "&" as query parameter separators; wsmancli
2.6 requires this. These URLs with work earlier wsmancli versions such
as 2. 3 as well.