### PR TITLE
ASM-6942 VSAN iDRAC configuration fails when RAID controller mode is not in HBA Mode

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -496,9 +496,8 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
     else
       if @boot_device =~ /VSAN/i
         if target_current_xml.to_s.match(/="CurrentControllerMode">RAID/)
-          changes['whole'][raid_configuration.keys.first] = { 'CurrentControllerMode' => "HBA"}
-          # Need to remove Virtual Disks when we move Controller from RAID to HBA mode.
-          raid_configuration.keys.each{|controller| changes['whole'][controller].merge!({ 'RAIDresetConfig' => "True" }) }
+          changes['whole'][raid_configuration.keys.first] = { 'CurrentControllerMode' => "HBA",
+                                                              'RAIDresetConfig' => "True" }
         end
       elsif @boot_device =~ /WITH_RAID|HD/i
         changes['partial'] = {'BIOS.Setup.1-1'=> {'HddSeq' => raid_configuration.keys.first}} if @boot_device =~ /HD/i


### PR DESCRIPTION
When RAID Controller is not in HBA mode, we have to set it to HBA and RAIDReset Attribute needs to be passed to ensure all the Virtual Disk and Hotspare configuration is removed.
Earlier code was trying to set the RAIDReset for all the RAID controllers which is not supported by iDRAC also initialization of the variable was not correct.