### PR TITLE
Removed RAID.Embedded.1.1 component from input XML for VSAN deployment on back-plane disk

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -500,8 +500,7 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
         if target_current_xml.to_s.match(/="CurrentControllerMode">RAID/)
           raids = (raid_configuration.keys || []).reject {|x| x.match(/Embedded/)}
           unless raids.empty?
-            changes['whole'][raids.first] = { 'CurrentControllerMode' => "HBA",
-                                              'RAIDresetConfig' => "True" }
+            changes['whole'][raids.first] = { 'CurrentControllerMode' => "HBA" }
           end
         end
       elsif @boot_device =~ /WITH_RAID|HD/i


### PR DESCRIPTION
- Current code was looking for the first RAID component and in certain cases RAID.Embedded component was getting picked instead of RAID.Integrated

- Removed RAID.Embedded component from the input XML in case installation disk in AHCI Mode
