### PR TITLE
ASM-7008 Added support for putting disks into nonraid mode

### DIFF
--- a/lib/puppet/provider/idrac.rb
+++ b/lib/puppet/provider/idrac.rb
@@ -64,7 +64,7 @@ class Puppet::Provider::Idrac <  Puppet::Provider
       in_sync &= check_removes(fqdd, children, "/SystemConfiguration", xml_base, "Component")
     end
     in_sync &= import_obj.raid_in_sync?(xml_base, true) if in_sync
-    return in_sync
+    in_sync
   end
 
   def check_for_important_attrs(xml_base, changes)
@@ -95,22 +95,22 @@ class Puppet::Provider::Idrac <  Puppet::Provider
         in_sync = false
       end
     end
-    return in_sync
+    in_sync
   end
 
   def check_changes(changes, path, xml_base)
     in_sync = true
     changes.each do |key, value|
-      if(value.is_a?(String))
+      if value.is_a?(String)
         node = xml_base.at_xpath("#{path}/Attribute[@Name='#{key}']")
         existing_val = node.nil? ? find_commented_attr_val(key, xml_base) : node.content
-        if(existing_val.nil?)
+        if existing_val.nil?
           Puppet.debug("Could not find a value for #{key} under FQDD at xpath #{path}. Will need need to import new configuration.")
           in_sync=false
-        elsif(existing_val != value)
-          if(key == "BiosBootSeq")
+        elsif existing_val != value
+          if key == "BiosBootSeq"
             compare = value.delete(' ').split(',').zip(existing_val.delete(' ').split(',')).select{|new_val, exist_val| new_val != exist_val}
-            if(compare.size != 0 && @resource[:ensure] != :teardown)
+            if compare.size != 0 && @resource[:ensure] != :teardown
               Puppet.debug("Value of BiosBootSeq does not match up. Existing Seq: #{existing_val}, trying to set to  #{value}")
               in_sync = false
               break
@@ -121,10 +121,10 @@ class Puppet::Provider::Idrac <  Puppet::Provider
             break
           end
         end
-      elsif(value.is_a?(Hash))
+      elsif value.is_a?(Hash)
         new_path = "#{path}/Component[@FQDD='#{key}']"
         in_sync &= check_changes(value, new_path, xml_base)
-        if(!in_sync)
+        unless in_sync
           break;
         end
       end

--- a/lib/puppet/provider/raid_configuration/default.rb
+++ b/lib/puppet/provider/raid_configuration/default.rb
@@ -1,0 +1,96 @@
+require 'puppet/idrac/util'
+require 'puppet_x/puppetlabs/transport/idrac'
+require 'asm/wsman'
+
+
+Puppet::Type.type(:raid_configuration).provide(:default, :parent => Puppet::Provider) do
+  desc "Dell idrac provider for managing raid configuration through wsman"
+
+  mk_resource_methods
+
+  def transport
+    @transport ||= begin
+      transport = PuppetX::Puppetlabs::Transport.retrieve(:resource_ref => resource[:transport], :catalog => resource.catalog, :provider => 'idrac')
+      Puppet::Idrac::Util.transport = transport.endpoint
+      transport.endpoint
+    end
+  end
+
+  def wsman
+    @wsman ||= ASM::WsMan.new(transport, :logger => Puppet)
+  end
+
+  def wsman_client
+    wsman.client
+  end
+
+  def flush
+    wsman.run_raid_config_job(:target => resource[:name])
+  end
+
+  def nonraid_disks
+    current_disk_modes[:nonraid]
+  end
+
+  def nonraid_disks=(disks)
+    reset_config
+    set_disk_modes(disks, :nonraid)
+  end
+
+  def raid_disks
+    current_disk_modes[:raid]
+  end
+
+  def raid_disks=(disks)
+    reset_config
+    set_disk_modes(disks, :raid)
+  end
+
+  def physical_disks
+    @physical_disks ||= wsman.physical_disk_views
+  end
+
+  def current_disk_modes
+    disk_modes = {:raid => [], :nonraid => []}
+
+    physical_disks.each do |disk|
+      if disk[:raid_status] == "8"
+        disk_modes[:nonraid] << disk[:fqdd]
+      else
+        disk_modes[:raid] << disk[:fqdd]
+      end
+    end
+
+    disk_modes
+  end
+
+  def reset_config
+    # Reset configuration job only needs to be triggered once, don't keep adding the same job
+    return if @reset_queued
+
+    wsman_client.invoke("ResetConfig", ASM::WsMan::RAID_SERVICE,
+                        :params => {:target => resource[:name]},
+                        :required_params => [:target],
+                        :optional_params => [],
+                        :return_value => "0")
+
+    @reset_queued = true
+  end
+
+  def set_disk_modes(disks_to_set, mode)
+    disks_to_set.each do |disk|
+      # We will get an error if we try to set the disk to the same mode it's already in
+      next if current_disk_modes[mode].include?(disk)
+
+      action = mode == :nonraid ? "ConvertToNonRAID" : "ConvertToRAID"
+      wsman_client.invoke(action, ASM::WsMan::RAID_SERVICE,
+                          :params => {"PDArray" => disk},
+                          :required_params => ["PDArray"],
+                          :optional_params => [],
+                          :return_value => "0")
+    end
+  end
+
+end
+
+

--- a/lib/puppet/type/raid_configuration.rb
+++ b/lib/puppet/type/raid_configuration.rb
@@ -1,0 +1,32 @@
+Puppet::Type.newtype(:raid_configuration) do
+  @doc = "RAID controller management for idracs."
+
+  newparam(:name) do
+    desc "The controller name to configure"
+
+    validate do |value|
+      if value.strip.length == 0
+        raise ArgumentError, "The name must contain a value. It cannot be null."
+      end
+    end
+  end
+
+  def self.disk_property(name)
+    newproperty(name) do
+      # override insync? to check if the list of disks already in mode
+      # contains all the disks trying to set, as opposed to checking
+      # that the 2 lists are exactly equal
+      def insync?(is)
+        (should - is).empty?
+      end
+      munge do |value|
+        return [value] if value && !value.is_a?(Array)
+        value.sort
+      end
+    end
+  end
+
+  disk_property(:raid_disks)
+  disk_property(:nonraid_disks)
+
+end


### PR DESCRIPTION
Importsystemconfiguration wsman action does not support changing raid
disk modes, so this functionality was added in a separate puppet type
using direct wsman commands.

This new type could potentially be used for any other raid configuration
workflows that importsystemconfiguration does not support, or that we
want to do before importsystemconfiguration happens.