### PR TITLE
ASM-7185 Win2008R2 Bare-Metal Install Failing with Error "O/S install  timed out"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ end
 group :development, :test do
   gem 'rake'
   gem 'rspec'
+  gem 'json_pure', '2.0.1' # pin this puppet dependency to 1.9-compat version
   gem 'puppetlabs_spec_helper'
   if puppetversion = ENV['PUPPET_GEM_VERSION']
     gem 'puppet', puppetversion

--- a/lib/puppet/idrac/util.rb
+++ b/lib/puppet/idrac/util.rb
@@ -47,9 +47,9 @@ module Puppet
 
       def self.virtual_disks_ready?
         response = view_disks
-        response.xpath('//DCIM_VirtualDiskView').each do |disk|
+        response.xpath('//DCIM_VIRTUALDiskView').each do |disk|
           current_op = disk.at_xpath('//OperationName').content
-          unless current_op =~ /None|Background/
+          if current_op =~ /Background/
             fqdd = disk.at_xpath('FQDD').content
             percent = disk.at_xpath('OperationPercentComplete').content
             Puppet.info("Virtual disk #{fqdd} is currently performing operation #{current_op} at #{percent} percent completion. Waiting...")

--- a/lib/puppet/idrac/util.rb
+++ b/lib/puppet/idrac/util.rb
@@ -47,7 +47,7 @@ module Puppet
 
       def self.virtual_disks_ready?
         response = view_disks
-        response.xpath('//DCIM_VIRTUALDiskView').each do |disk|
+        response.xpath('//DCIM_VirtualDiskView').each do |disk|
           current_op = disk.at_xpath('//OperationName').content
           if current_op =~ /Background/
             fqdd = disk.at_xpath('FQDD').content

--- a/spec/fixtures/VirtualDiskView.xml
+++ b/spec/fixtures/VirtualDiskView.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration">
+  <s:Header>
+    <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+    <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</wsa:Action>
+    <wsa:RelatesTo>uuid:9d757e78-389c-189c-8002-b25892565000</wsa:RelatesTo>
+    <wsa:MessageID>uuid:9eb9f55a-389c-189c-be59-bfa398369810</wsa:MessageID>
+  </s:Header>
+  <s:Body>
+    <wsen:EnumerateResponse>
+      <wsen:EnumerationContext>9eb8c7e2-389c-189c-be58-bfa398369810</wsen:EnumerationContext>
+    </wsen:EnumerateResponse>
+  </s:Body>
+</s:Envelope>
+        <?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:n1="http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_VIRTUALDiskView">
+<s:Header>
+  <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+  <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</wsa:Action>
+  <wsa:RelatesTo>uuid:9d95474b-389c-189c-8003-b25892565000</wsa:RelatesTo>
+  <wsa:MessageID>uuid:9ebc7392-389c-189c-be5a-bfa398369810</wsa:MessageID>
+</s:Header>
+<s:Body>
+  <wsen:PullResponse>
+    <wsen:Items>
+      <n1:DCIM_VIRTUALDiskView>
+        <n1:BlockSizeInBytes>512</n1:BlockSizeInBytes>
+        <n1:BusProtocol>6</n1:BusProtocol>
+        <n1:Cachecade>0</n1:Cachecade>
+        <n1:DeviceDescription>Virtual Disk 0 on Integrated RAID Controller 1</n1:DeviceDescription>
+        <n1:DiskCachePolicy>1024</n1:DiskCachePolicy>
+        <n1:FQDD>Disk.Virtual.0:RAID.Integrated.1-1</n1:FQDD>
+        <n1:InstanceID>Disk.Virtual.0:RAID.Integrated.1-1</n1:InstanceID>
+        <n1:LastSystemInventoryTime>20160727114522.000000+000</n1:LastSystemInventoryTime>
+        <n1:LastUpdateTime>20160727124512.000000+000</n1:LastUpdateTime>
+        <n1:LockStatus>0</n1:LockStatus>
+        <n1:MediaType>1</n1:MediaType>
+        <n1:Name>ASM VD0</n1:Name>
+        <n1:ObjectStatus>0</n1:ObjectStatus>
+        <n1:OperationName>Background Initialization</n1:OperationName>
+        <n1:OperationPercentComplete>97</n1:OperationPercentComplete>
+        <n1:PendingOperations>0</n1:PendingOperations>
+        <n1:PhysicalDiskIDs>Disk.Bay.0:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:PhysicalDiskIDs>
+        <n1:PhysicalDiskIDs>Disk.Bay.1:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:PhysicalDiskIDs>
+        <n1:PrimaryStatus>1</n1:PrimaryStatus>
+        <n1:RAIDStatus>2</n1:RAIDStatus>
+        <n1:RAIDTypes>4</n1:RAIDTypes>
+        <n1:ReadCachePolicy>64</n1:ReadCachePolicy>
+        <n1:RemainingRedundancy>1</n1:RemainingRedundancy>
+        <n1:RollupStatus>1</n1:RollupStatus>
+        <n1:SizeInBytes>299439751168</n1:SizeInBytes>
+        <n1:SpanDepth>1</n1:SpanDepth>
+        <n1:SpanLength>2</n1:SpanLength>
+        <n1:StartingLBAinBlocks>0</n1:StartingLBAinBlocks>
+        <n1:StripeSize>128</n1:StripeSize>
+        <n1:T10PIStatus>0</n1:T10PIStatus>
+        <n1:VirtualDiskTargetID>0</n1:VirtualDiskTargetID>
+        <n1:WriteCachePolicy>2</n1:WriteCachePolicy>
+      </n1:DCIM_VIRTUALDiskView>
+    </wsen:Items>
+    <wsen:EndOfSequence/>
+  </wsen:PullResponse>
+</s:Body>
+</s:Envelope>

--- a/spec/fixtures/VirtualDiskView.xml
+++ b/spec/fixtures/VirtualDiskView.xml
@@ -23,7 +23,7 @@
 <s:Body>
   <wsen:PullResponse>
     <wsen:Items>
-      <n1:DCIM_VIRTUALDiskView>
+      <n1:DCIM_VirtualDiskView>
         <n1:BlockSizeInBytes>512</n1:BlockSizeInBytes>
         <n1:BusProtocol>6</n1:BusProtocol>
         <n1:Cachecade>0</n1:Cachecade>
@@ -56,7 +56,7 @@
         <n1:T10PIStatus>0</n1:T10PIStatus>
         <n1:VirtualDiskTargetID>0</n1:VirtualDiskTargetID>
         <n1:WriteCachePolicy>2</n1:WriteCachePolicy>
-      </n1:DCIM_VIRTUALDiskView>
+      </n1:DCIM_VirtualDiskView>
     </wsen:Items>
     <wsen:EndOfSequence/>
   </wsen:PullResponse>

--- a/spec/fixtures/VirtualDiskView2.xml
+++ b/spec/fixtures/VirtualDiskView2.xml
@@ -23,7 +23,7 @@
 <s:Body>
   <wsen:PullResponse>
     <wsen:Items>
-      <n1:DCIM_VIRTUALDiskView>
+      <n1:DCIM_VirtualDiskView>
         <n1:BlockSizeInBytes>512</n1:BlockSizeInBytes>
         <n1:BusProtocol>6</n1:BusProtocol>
         <n1:Cachecade>0</n1:Cachecade>
@@ -56,7 +56,7 @@
         <n1:T10PIStatus>0</n1:T10PIStatus>
         <n1:VirtualDiskTargetID>0</n1:VirtualDiskTargetID>
         <n1:WriteCachePolicy>2</n1:WriteCachePolicy>
-      </n1:DCIM_VIRTUALDiskView>
+      </n1:DCIM_VirtualDiskView>
     </wsen:Items>
     <wsen:EndOfSequence/>
   </wsen:PullResponse>

--- a/spec/fixtures/VirtualDiskView2.xml
+++ b/spec/fixtures/VirtualDiskView2.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration">
+  <s:Header>
+    <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+    <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</wsa:Action>
+    <wsa:RelatesTo>uuid:51b5aa54-389d-189d-8002-b25892565000</wsa:RelatesTo>
+    <wsa:MessageID>uuid:53395b9b-389d-189d-80b9-bfa398369810</wsa:MessageID>
+  </s:Header>
+  <s:Body>
+    <wsen:EnumerateResponse>
+      <wsen:EnumerationContext>53197982-389d-189d-80b5-bfa398369810</wsen:EnumerationContext>
+    </wsen:EnumerateResponse>
+  </s:Body>
+</s:Envelope>
+        <?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:n1="http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_VIRTUALDiskView">
+<s:Header>
+  <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+  <wsa:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</wsa:Action>
+  <wsa:RelatesTo>uuid:521628c7-389d-189d-8003-b25892565000</wsa:RelatesTo>
+  <wsa:MessageID>uuid:53444bcf-389d-189d-80bc-bfa398369810</wsa:MessageID>
+</s:Header>
+<s:Body>
+  <wsen:PullResponse>
+    <wsen:Items>
+      <n1:DCIM_VIRTUALDiskView>
+        <n1:BlockSizeInBytes>512</n1:BlockSizeInBytes>
+        <n1:BusProtocol>6</n1:BusProtocol>
+        <n1:Cachecade>0</n1:Cachecade>
+        <n1:DeviceDescription>Virtual Disk 0 on Integrated RAID Controller 1</n1:DeviceDescription>
+        <n1:DiskCachePolicy>1024</n1:DiskCachePolicy>
+        <n1:FQDD>Disk.Virtual.0:RAID.Integrated.1-1</n1:FQDD>
+        <n1:InstanceID>Disk.Virtual.0:RAID.Integrated.1-1</n1:InstanceID>
+        <n1:LastSystemInventoryTime>20160727114522.000000+000</n1:LastSystemInventoryTime>
+        <n1:LastUpdateTime>20160727124512.000000+000</n1:LastUpdateTime>
+        <n1:LockStatus>0</n1:LockStatus>
+        <n1:MediaType>1</n1:MediaType>
+        <n1:Name>ASM VD0</n1:Name>
+        <n1:ObjectStatus>0</n1:ObjectStatus>
+        <n1:OperationName>None</n1:OperationName>
+        <n1:OperationPercentComplete>0</n1:OperationPercentComplete>
+        <n1:PendingOperations>0</n1:PendingOperations>
+        <n1:PhysicalDiskIDs>Disk.Bay.0:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:PhysicalDiskIDs>
+        <n1:PhysicalDiskIDs>Disk.Bay.1:Enclosure.Internal.0-1:RAID.Integrated.1-1</n1:PhysicalDiskIDs>
+        <n1:PrimaryStatus>1</n1:PrimaryStatus>
+        <n1:RAIDStatus>2</n1:RAIDStatus>
+        <n1:RAIDTypes>4</n1:RAIDTypes>
+        <n1:ReadCachePolicy>64</n1:ReadCachePolicy>
+        <n1:RemainingRedundancy>1</n1:RemainingRedundancy>
+        <n1:RollupStatus>1</n1:RollupStatus>
+        <n1:SizeInBytes>299439751168</n1:SizeInBytes>
+        <n1:SpanDepth>1</n1:SpanDepth>
+        <n1:SpanLength>2</n1:SpanLength>
+        <n1:StartingLBAinBlocks>0</n1:StartingLBAinBlocks>
+        <n1:StripeSize>128</n1:StripeSize>
+        <n1:T10PIStatus>0</n1:T10PIStatus>
+        <n1:VirtualDiskTargetID>0</n1:VirtualDiskTargetID>
+        <n1:WriteCachePolicy>2</n1:WriteCachePolicy>
+      </n1:DCIM_VIRTUALDiskView>
+    </wsen:Items>
+    <wsen:EndOfSequence/>
+  </wsen:PullResponse>
+</s:Body>
+</s:Envelope>

--- a/spec/unit/puppet/provider/importtemplatexml_spec.rb
+++ b/spec/unit/puppet/provider/importtemplatexml_spec.rb
@@ -398,4 +398,22 @@ describe Puppet::Provider::Importtemplatexml do
       comp.at_xpath("Attribute[@Name='iScsiOffloadMode']").should == nil
     end
   end
+
+  context "return disk initiatlization status" do
+    before(:each) do
+      @test_config_dir = URI( File.expand_path("../../../../fixtures", __FILE__))
+    end
+
+    it "should return false when disk initiatlization is not completed" do
+      view_disk_xml = File.read(@test_config_dir.path + '/VirtualDiskView.xml')
+      ASM::WsMan.stub(:invoke).and_return(view_disk_xml)
+      Puppet::Idrac::Util.virtual_disks_ready?.should  == false
+    end
+
+    it "should return true when disk initiatlization is completed" do
+      view_disk_xml = File.read(@test_config_dir.path + '/VirtualDiskView2.xml')
+      ASM::WsMan.stub(:invoke).and_return(view_disk_xml)
+      Puppet::Idrac::Util.virtual_disks_ready?.should  == true
+    end
+  end
 end


### PR DESCRIPTION
Disk initialization XML output has changed. As a result we were not waiting for the disk initialization to complete that was leading to intermittent Windows OS installation failure. This has been observed with Windows 2008R2 very consistently and occasionally with Windows 2012 / HyperV deployments.