### PR TITLE
ASM-7383 Teardown of non-RAID disks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :development, :test do
   gem 'rake'
   gem 'rspec'
   gem 'puppetlabs_spec_helper'
+  gem 'json_pure', '2.0.1'
   if puppetversion = ENV['PUPPET_GEM_VERSION']
     gem 'puppet', puppetversion
   else


### PR DESCRIPTION
If non-RAID disks exist, on teardown we need to convert
these to a RAID virtual disk so we can re-use the server