### PR TITLE
ASM-7423 Deployment teardown throws exception in logs

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -487,7 +487,7 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
               raid_configuration[controller][:hotspares] << disk
             end
             Puppet.debug("Inside VSAN RAID Configuration: #{raid_configuration}")
-          elsif !(unprocessed['virtualDisks'].empty? && unprocessed['externalVirtualDisks'].empty?)
+          elsif !(unprocessed['virtualDisks'] && unprocessed['virtualDisks'].empty? && unprocessed['externalVirtualDisks'] && unprocessed['externalVirtualDisks'].empty?)
             (unprocessed['virtualDisks'] + unprocessed['externalVirtualDisks']).each do |config|
               #Just check first disk in the list to get what type of virtual disk it is
               type = disk_types[config["physicalDisks"].first]


### PR DESCRIPTION
The deployment teardown did not have RAID config specified in deployment.json.
As a result, asm::idrac had set raid_configuration to {}, which later on
results in nil class exception in the puppet module.

The fix is to have safety nil checks before invoking empty? method