### PR TITLE
ASM-7413 Remove SD card redundancy for HD deployments

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -182,6 +182,9 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
     if @boot_device =~ /HD/i
       #We turn off SD card in case of Hdd boot.  We don't want it on to potentially interfere with the esxi boot order (it doesn't follow the BiosBootSeq)
       changes["partial"].deep_merge!("BIOS.Setup.1-1" => {"InternalSdCard" => "Off"})
+      # since we set SD card to off, ensure we don't set any other SD card related attributes
+      changes["remove"]["attributes"]["BIOS.Setup.1-1"] ||= []
+      changes["remove"]["attributes"]["BIOS.Setup.1-1"].push("InternalSdCardRedundancy", "InternalSdCardPrimaryCard")
     end
     #Boot Device could be SD_WITHOUT_RAID or SD_WITH_RAID.  Raid Settings are handled above for WITH_RAID
     if @boot_device =~ /SD/i


### PR DESCRIPTION
Sometimes when deploying OS to HD to server whose internal SD redundancy was disabled/mirror prior to import config xml, we can end up setting config xml with SD off and *some* value for SD redundancy which can cause import config job to fail.

The fix for such scenario is to explicitly remove SD related attributes
when we set SD to off for HD deployments.