### PR TITLE
ASM-7561: removed boot Hddseq if it is already set in idrac

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -335,8 +335,10 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
   def remove_invalid_settings(xml_to_edit)
     # HddSeq seems to cause a lot of issues by letting it stay.
     # We only allow it to stay if we're specifically trying to set it for booting from hard drive
-    hdd_seq = find_attribute_value(xml_to_edit, 'BIOS.Setup.1-1', 'HddSeq', false)
-    hdd_seq.remove unless hdd_seq.nil? || @changes['partial']['BIOS.Setup.1-1']['HddSeq']
+    hdd_seq = find_attribute_value(xml_to_edit, 'BIOS.Setup.1-1', 'HddSeq', true)
+    if @changes['partial']['BIOS.Setup.1-1']['HddSeq']
+    @changes['partial']['BIOS.Setup.1-1'].delete('HddSeq') if hdd_seq.eql?(@changes['partial']['BIOS.Setup.1-1']['HddSeq'].split(",").first)
+    end
     # Compare the changes to BIOS.Setup.1-1 with the bios settings that exist on the target server.
     # We do not attempt to set if we cannot find the bios setting in the server's BIOS enumeration
     bios_settings = xml_to_edit.xpath("//Component[@FQDD='BIOS.Setup.1-1']/Attribute")

--- a/spec/unit/puppet/provider/importtemplatexml_spec.rb
+++ b/spec/unit/puppet/provider/importtemplatexml_spec.rb
@@ -314,6 +314,7 @@ describe Puppet::Provider::Importtemplatexml do
       ASM::NetworkConfiguration.stub(:new).and_return(net_config)
       ASM::WsMan.stub(:invoke).and_return(@view_disk_xml)
       Puppet::Provider::Importtemplatexml.any_instance.stub(:get_raid_config_changes).and_return({})
+      Puppet::Provider::Importtemplatexml.any_instance.stub(:find_attribute_value).and_return("RAID.Integrated.1-1")
       @fixture.stub(:find_target_bios_setting).and_return("value")
       @fixture.stub(:find_target_bios_setting).with('InvalidAttribute').and_return(nil)
       #The xml that @fixture will read (FOOTAG_original) will have the InvalidAttribute attribute. It should not exist after munging.


### PR DESCRIPTION
Previously Idrac job runs forever if the same boot sequesnce is set again. In this PR it removes the Hddseq if it is already set.