### PR TITLE
ASM-7503 IDRAC changes to support SATADOM boot drive option

### DIFF
--- a/lib/puppet/idrac/util.rb
+++ b/lib/puppet/idrac/util.rb
@@ -59,6 +59,11 @@ module Puppet
         true
       end
 
+      def self.boot_source_settings
+        require 'asm/wsman'
+        ASM::WsMan.new(get_transport).boot_source_settings
+      end
+
       #This method waits for any running jobs to complete, and raises an exception after 5 minutes
       def self.wait_for_running_jobs
         require 'asm/wsman'

--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -199,7 +199,7 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
       changes["partial"].deep_merge!("BIOS.Setup.1-1" => {"EmbSata" => "AhciMode"})
       changes["partial"].deep_merge!("BIOS.Setup.1-1" => {"SecurityFreezeLock" => "Disabled"})
       changes["partial"].deep_merge!("BIOS.Setup.1-1" => {"WriteCache" => "Disabled"})
-      changes["partial"].deep_merge!("BIOS.Setup.1-1" => {"HddSeq" => get_first_sata_disk})
+      changes["partial"].deep_merge!("BIOS.Setup.1-1" => {"HddSeq" => get_boot_sata_disk})
       changes["partial"].deep_merge!("BIOS.Setup.1-1" => {"InternalSdCard" => "Off"}) if is_sd_card?
     elsif @boot_device =~ /VSAN/i
       changes["partial"].deep_merge!("BIOS.Setup.1-1" => {"InternalSdCard" => "On"})
@@ -230,6 +230,18 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
       sd_disks << x.at_xpath('FQDD') if x.at_xpath('MediaType').text != '0'
     end
     !sd_disks.empty?
+  end
+
+  def get_boot_sata_disk
+    # If we find a SATADOM device, prefer it, else fallback to getting first SATA disk
+    boot_sources = Puppet::Idrac::Util.boot_source_settings
+    satadom_instance_id = boot_sources.select {|d| d[:boot_string] =~ /SATADOM/}[0][:instance_id] rescue nil
+    if satadom_instance_id
+      Puppet.debug("Prefering SATADOM disk for booting")
+      satadom_instance_id.split("#")[2]
+    else
+      get_first_sata_disk
+    end
   end
 
   def get_first_sata_disk

--- a/spec/unit/puppet/provider/importtemplatexml_spec.rb
+++ b/spec/unit/puppet/provider/importtemplatexml_spec.rb
@@ -401,4 +401,72 @@ describe Puppet::Provider::Importtemplatexml do
       comp.at_xpath("Attribute[@Name='iScsiOffloadMode']").should == nil
     end
   end
+
+   context "when getting SATA disk for boot" do
+     it "should raise error if no SATA disk is found" do
+       ASM::WsMan.stub(:invoke).and_return("")
+       expect { @fixture.get_first_sata_disk }.to raise_error(RuntimeError, /Embedded SATA Disk not found/)
+     end
+
+     it "should find SATADOM when found in boot source settings" do
+       mock_boot_source_settings = [
+         {
+           :bios_boot_string=>"NIC in Slot 1 Port 2 Partition 1: IBA XE Slot 0401 v2334 BootSeq",
+           :boot_source_type=>"IPL",
+           :boot_string=>"NIC in Slot 1 Port 2 Partition 1: IBA XE Slot 0401 v2334 BootSeq",
+           :current_assigned_sequence=>"5",
+           :current_enabled_status=>"1",
+           :instance_id=>"IPL:BIOS.Setup.1-1#BootSeq#NIC.Slot.1-2-1#27d35f79888d0fa3f74312ff1da778fb"
+         },
+         {
+            :bios_boot_string=>"Embedded SATA Port Disk J: SATADOM-ML 3ME HddSeq",
+            :boot_source_type=>"BCV",
+            :boot_string=>"Embedded SATA Port Disk J: SATADOM-ML 3ME HddSeq",
+            :current_assigned_sequence=>"0",
+            :current_enabled_status=>"1",
+            :instance_id=>"BCV:BIOS.Setup.1-1#HddSeq#Disk.SATAEmbedded.J-1#4e861c42e369a695a66a0cd22fd492c3"
+         }
+       ]
+       Puppet::Idrac::Util.stub(:boot_source_settings).and_return(mock_boot_source_settings)
+       expect(@fixture.get_boot_sata_disk).to eq("Disk.SATAEmbedded.J-1")
+     end
+
+     it "should return any available SATA disk if SATADOM is not found" do
+       mock_boot_source_settings = [
+           {
+               :bios_boot_string=>"NIC in Slot 1 Port 2 Partition 1: IBA XE Slot 0401 v2334 BootSeq",
+               :boot_source_type=>"IPL",
+               :boot_string=>"NIC in Slot 1 Port 2 Partition 1: IBA XE Slot 0401 v2334 BootSeq",
+               :current_assigned_sequence=>"5",
+               :current_enabled_status=>"1",
+               :instance_id=>"IPL:BIOS.Setup.1-1#BootSeq#NIC.Slot.1-2-1#27d35f79888d0fa3f74312ff1da778fb"
+           }
+       ]
+
+       mock_physical_disks = <<EOF
+        <?xml version="1.0" encoding="UTF-8"?>
+        <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsen="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:n1="http://schemas.dell.com/wbem/wscim/1/cim-schema/2/DCIM_PhysicalDiskView">
+        <s:Body>
+        <wsen:PullResponse>
+          <wsen:Items>
+            <n1:DCIM_PhysicalDiskView>
+              <n1:FQDD>Disk.Direct.5-9:AHCI.Embedded.2-1</n1:FQDD>
+              <n1:FreeSizeInBytes>0</n1:FreeSizeInBytes>
+              <n1:HotSpareStatus>0</n1:HotSpareStatus>
+              <n1:InstanceID>Disk.Direct.5-9:AHCI.Embedded.2-1</n1:InstanceID>
+              <n1:BusProtocol>5</n1:BusProtocol>
+              <n1:Connector>5</n1:Connector>
+              <n1:Slot>5</n1:Slot>
+            </n1:DCIM_PhysicalDiskView>
+          </wsen:Items>
+          <wsen:EndOfSequence/>
+        </wsen:PullResponse>
+        </s:Body>
+        </s:Envelope>
+EOF
+       ASM::WsMan.stub(:invoke).and_return(mock_physical_disks)
+       Puppet::Idrac::Util.stub(:boot_source_settings).and_return(mock_boot_source_settings)
+       expect(@fixture.get_boot_sata_disk).to eq("Disk.SATAEmbedded.F-1")
+     end
+   end
 end


### PR DESCRIPTION
As per requirement, we prefer SATADOM disk when retrieving SATA disks
for AHCI VSAN mode.