### PR TITLE
ASM-7503 Fix teardown NilClass exception when there are no RAID disks

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -506,7 +506,7 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
               raid_configuration[controller][:hotspares] << disk
             end
             Puppet.debug("Inside VSAN RAID Configuration: #{raid_configuration}")
-          elsif unprocessed.nil?
+          elsif unprocessed.nil? || unprocessed.empty?
             Puppet.debug("No RAID Configuration required")
           elsif !(unprocessed['virtualDisks'] && unprocessed['virtualDisks'].empty? && unprocessed['externalVirtualDisks'] && unprocessed['externalVirtualDisks'].empty?)
             (unprocessed['virtualDisks'] + unprocessed['externalVirtualDisks']).each do |config|


### PR DESCRIPTION
Problem:
In the raid_configuration, if there are no RAID config to process (like
SATADOM) the unprocessed hash may be empty, resulting into any looked up
value in this hash as nil e.g. unprocessed['virtualDisks']. Accessing
methods from looked up value results into nil class exception.

Solution:
The check for determining "no RAID config needed" needs to include empty
hash check along with nil value check.