### PR TITLE
ASM-7744 Support for RAID on S130

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+Gemfile.lock

--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -22,6 +22,11 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
   end
 
   def importtemplatexml
+    unless embsata_in_sync?
+      Puppet.debug("Embedded Sata settings out of sync. Need to configure first.")
+      munge_config_xml(true)
+      execute_import
+    end
     munge_config_xml unless @xml_processed
     execute_import
   end
@@ -185,6 +190,9 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
       # since we set SD card to off, ensure we don't set any other SD card related attributes
       changes["remove"]["attributes"]["BIOS.Setup.1-1"] ||= []
       changes["remove"]["attributes"]["BIOS.Setup.1-1"].push("InternalSdCardRedundancy", "InternalSdCardPrimaryCard")
+      if is_embedded_raid?
+        changes["partial"].deep_merge!("BIOS.Setup.1-1" => {"EmbSata" => "RaidMode"})
+      end
     end
     #Boot Device could be SD_WITHOUT_RAID or SD_WITH_RAID.  Raid Settings are handled above for WITH_RAID
     if @boot_device =~ /SD/i
@@ -265,14 +273,14 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
     xml_doc.xpath('/SystemConfiguration').first
   end
 
-  def munge_config_xml
+  def munge_config_xml(emb_mode_change=false)
     get_config_changes
     xml_base.xpath("//Component[contains(@FQDD, 'NIC.') or contains(@FQDD, 'FC.')]").remove unless @changes['whole'].find_all{|k,v| k =~ /^(NIC|FC)\./}.empty?
     xml_base['ServiceTag'] = @resource[:servicetag]
 
     handle_missing_devices(xml_base, @changes)
     @nonraid_to_raid = false
-    @changes.deep_merge!(get_raid_config_changes(xml_base))
+    @changes.deep_merge!(get_raid_config_changes(xml_base)) unless emb_mode_change
 
     %w(BiosBootSeq HddSeq).each do |attr|
       existing_attr_val = find_bios_attribute(xml_base, attr)
@@ -885,6 +893,28 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
       end
     end
     attr_node.nil? ? nil : attr_node.content
+  end
+
+  # Returns true if this is a deployment to an embedded raid (S130) controller
+  #
+  # @return Boolean
+  def is_embedded_raid?
+    virtual_disks = @resource[:raid_configuration].fetch("virtualDisks", [])
+    virtual_disks.each do |vd|
+      controller = vd.fetch("controller", "")
+      return true if controller.match(/Embedded/i)
+    end
+    false
+  end
+
+  # Check for Embedded Sata in sync
+  #
+  # If the current embedded sata mode is not what is required
+  # this method returns true
+  # @return Boolean
+  def embsata_in_sync?
+    return true unless is_embedded_raid?
+    find_bios_attribute(original_xml, "EmbSata") == "RaidMode"
   end
 end
 

--- a/spec/fixtures/BARTAG_original.xml
+++ b/spec/fixtures/BARTAG_original.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SystemConfiguration Model="PowerEdge M620" ServiceTag="" TimeStamp="">
+
+  <Component FQDD="BIOS.Setup.1-1">
+    <Attribute Name="ProcVirtualization">Enabled</Attribute>
+    <Attribute Name="BootMode">Bios</Attribute>
+    <Attribute Name="IntegratedRaid">Enabled</Attribute>
+    <Attribute Name="InternalSdCard">Enabled</Attribute>
+    <Attribute Name="EmbSata">RaidMode</Attribute>
+    <Attribute Name="BiosBootSeq">NIC.Integrated.1-1-3, HardDisk.List.1-1</Attribute>
+  </Component>
+  <Component FQDD="NIC.Integrated.1-1-1">
+    <Attribute Name="VirtualizationMode">NONE</Attribute>
+  </Component>
+  <Component FQDD="NIC.Integrated.1-2-1">
+    <Attribute Name="VirtualizationMode">NONE</Attribute>
+  </Component>
+  <Component FQDD="RAID.Integrated.1-1">
+    <Attribute Name="VirtualizationMode">NONE</Attribute>
+  </Component>
+
+</SystemConfiguration>
+

--- a/spec/fixtures/FOOTAG_original.xml
+++ b/spec/fixtures/FOOTAG_original.xml
@@ -6,6 +6,7 @@
   <Attribute Name="BootMode">Bios</Attribute>
   <Attribute Name="IntegratedRaid">Enabled</Attribute>
   <Attribute Name="InternalSdCard">Enabled</Attribute>
+  <Attribute Name="EmbSata">AhciMode</Attribute>
   <Attribute Name="BiosBootSeq">NIC.Integrated.1-1-3, HardDisk.List.1-1</Attribute>
 </Component>
 <Component FQDD="NIC.Integrated.1-1-1">

--- a/spec/unit/puppet/provider/importtemplatexml_spec.rb
+++ b/spec/unit/puppet/provider/importtemplatexml_spec.rb
@@ -401,4 +401,34 @@ describe Puppet::Provider::Importtemplatexml do
       comp.at_xpath("Attribute[@Name='iScsiOffloadMode']").should == nil
     end
   end
+
+  describe "#is_embedded_raid?" do
+    it "should return false when no virtual disks use embedded controllers" do
+      expect(@fixture.is_embedded_raid?).to eq(false)
+    end
+
+    it "should return true when there are virtual disks on embedded controller" do
+      resource = {:raid_configuration => {"virtualDisks" => [{"controller" => "NonRAID.Embedded.2-1"}]}}
+      @fixture.instance_variable_set(:@resource, resource)
+      expect(@fixture.is_embedded_raid?).to eq(true)
+    end
+  end
+
+  describe "#embsata_in_sync?" do
+    it "should return true when embSata Raid not required" do
+      expect(@fixture.embsata_in_sync?).to eq(true)
+    end
+
+    it "should return true when embSata required but mode is already set" do
+      resource = {:configxmlfilename => "BARTAG.xml", :nfssharepath => @test_config_dir.path.to_s}
+      @fixture.stub(:is_embedded_raid?).and_return(true)
+      @fixture.instance_variable_set(:@resource, resource)
+      expect(@fixture.embsata_in_sync?).to eq(true)
+    end
+
+    it "should return false when embSata Raid required and not current" do
+      @fixture.stub(:is_embedded_raid?).and_return(true)
+      expect(@fixture.embsata_in_sync?).to eq(false)
+    end
+  end
 end

--- a/spec/unit/puppet/provider/importtemplatexml_spec.rb
+++ b/spec/unit/puppet/provider/importtemplatexml_spec.rb
@@ -431,6 +431,7 @@ describe Puppet::Provider::Importtemplatexml do
       expect(@fixture.embsata_in_sync?).to eq(false)
     end
   end
+
    context "when getting SATA disk for boot" do
      it "should raise error if no SATA disk is found" do
        ASM::WsMan.stub(:invoke).and_return("")


### PR DESCRIPTION
Allow deployments to S130 embedded RAID card when that card is selected.
If the Embedded controller is currently in a mode other than "RaidMode"
we will have to configure that first before we can do any other configurations.
This will result in 2 passes of the import system config