### PR TITLE
ASM-8013 Fix nil:NilClass for embedded raid check

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -918,6 +918,7 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
   #
   # @return Boolean
   def is_embedded_raid?
+    return false unless @resource[:raid_configuration]
     virtual_disks = @resource[:raid_configuration].fetch("virtualDisks", [])
     virtual_disks.each do |vd|
       controller = vd.fetch("controller", "")


### PR DESCRIPTION
Deployments that do not contain a raid configuration will cause
failures due to null pointer.  This fixes that