### PR TITLE
ASM-7905 Puppet provider for server onboarding

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,3 @@
+fixtures:
+  repositories:
+    transport: "https://github.com/dell-asm/puppet-transport.git"

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
-require 'rake'
-require 'rspec/core/rake_task'
+require "rake"
+require "puppetlabs_spec_helper/rake_tasks"
+require "rspec/core/rake_task"
 
 # Customize lint option
 task :lint do
@@ -31,7 +32,7 @@ namespace :rspec do
     end
   end
 end
-task :default => :rspec
+task :default => :spec
 
 begin
   if Gem::Specification::find_by_name('puppet-lint')

--- a/lib/puppet/provider/idrac_racadm.rb
+++ b/lib/puppet/provider/idrac_racadm.rb
@@ -1,15 +1,21 @@
+require "pathname"
 begin
-  require 'puppet_x/puppetlabs/transport'
-  require 'puppet_x/puppetlabs/transport/racadm'
-rescue LoadError
-  require 'pathname' # WORK_AROUND #14073 and #7788
-  mod = Puppet::Module.find('transport', Puppet[:environment].to_s)
-  require File.join mod.path, 'lib/puppet_x/puppetlabs/transport'
-  require File.join mod.path, 'lib/puppet_x/puppetlabs/transport/racadm'
+  require "puppet_x/puppetlabs/transport"
+rescue LoadError # WORK_AROUND #14073 and #7788
+  mod = Puppet::Module.find("transport", Puppet[:environment].to_s)
+  require File.join mod.path, "lib/puppet_x/puppetlabs/transport" if mod
+end
+begin
+  require "puppet_x/puppetlabs/transport/racadm"
+rescue LoadError # WORK_AROUND #14073 and #7788
+  mod = Puppet::Module.find("transport", Puppet[:environment].to_s)
+  begin
+    require File.join mod.path, "lib/puppet_x/puppetlabs/transport/racadm" if mod
+  rescue LoadError  # This would happen in CI scenario, ignore it since we anyways will mock racadm out
+  end
 end
 
 class Puppet::Provider::IdracRacadm <  Puppet::Provider
-
   def local_permissions
     {"Administrator" => "0x1ff", "Operator" => "0x1f3", "ReadOnly" => "0x1", "None" => "0x0"}
   end
@@ -23,60 +29,85 @@ class Puppet::Provider::IdracRacadm <  Puppet::Provider
   end
 
   def client
-    @transport ||= PuppetX::Puppetlabs::Transport.retrieve(:resource_ref => resource[:transport], :catalog => resource.catalog, :provider => 'racadm')
+    @transport ||= PuppetX::Puppetlabs::Transport.retrieve(:resource_ref => resource[:transport], :catalog => resource.catalog, :provider => "racadm")
     @transport.ssh
   end
 
-  def racadm_cmd(subcommand, flags={}, params='')
-    cmd = "racadm #{subcommand}"
-    if(!params.empty?)
-      param_string = param_values.is_a?(Array) ? params.join(" ") : params.to_s
-      cmd << " #{param_string}"
-    end
+  # Racadm command
+  #
+  # Executes desired racadm command and parses resulting output
+  #
+  # @param subcommand [String] racadm subcommand to invoke
+  # @param params [Array<String>] list of params to be appended to racadm set <fqdd>.<group>.<object>.<index>
+  # @param process_opts [Hash] extra options for processing results
+  # @option process_opts [Boolean] :raise_on_err flag to indicate whether to raise exception if command errs
+  # @return [Object] output for the command result. Can be either a string, or list of strings
+  # @raise [StandardError] when racadm command fails and :raise_on_err flag is set
+  def racadm_cmd(subcommand, params=[], process_opts={})
+    cmd = "racadm %s" % subcommand
+    cmd << " %s" % Array(params).join(" ")unless params.empty?
     output = client.exec!(cmd)
-    Puppet.info("racadm #{subcommand} result: #{output}")
-    Puppet.err("Could not send command racadm #{subcommand}") if output.include?('ERROR:')
+    Puppet.info("racadm %s result: %s" % [subcommand, output])
+    if output.include?("ERROR:")
+      msg = "Error in racadm command %s" % subcommand
+      Puppet.err(msg)
+      raise msg if process_opts[:raise_on_err]
+    else
+      Puppet.info("Successfully executed %s" % subcommand)
+    end
     parse_output_values(output)
   end
 
-  def racadm_set(fqdd, group, config_object='', params=[], index='')
-    path = "#{fqdd}.#{group}.#{config_object}"
-    if(!index.to_s.empty?)
-      path << ".#{index}"
-    end
-    cmd = "racadm set #{path}"
-    if(!params.empty?)
-      param_string = params.is_a?(Array) ? params.join(' ') : params.to_s
-      cmd << " #{param_string}"
-    end
-    output = client.exec!(cmd)
-    Puppet.info("racadm_set result: #{output}")
-    Puppet.err("Could not set #{path}") if output.include?('ERROR:')
-    parse_output_values(output)
+  # Racadm set command
+  #
+  # Executes desired racadm set command and parses resulting output
+  #
+  # @param fqdd [String] FQDD to be used in racadm set <fqdd>.<group>.<object>.<index>
+  # @param group [String] group to be used in racadm set <fqdd>.<group>.<object>.<index>
+  # @param config_object [String] config to be used in racadm set <fqdd>.<group>.<object>.<index>
+  # @param params [Array<String>] list of params to be appended to racadm set <fqdd>.<group>.<object>.<index>
+  # @param index [String] index to be used in racadm set <fqdd>.<group>.<object>.<index>
+  # @param process_opts [Hash] extra options for processing results
+  # @option process_opts [Boolean] :raise_on_err flag to indicate whether to raise exception if command errs
+  # @return [Object] output for the command result. Can be either a string, or list of strings
+  # @raise [StandardError] when racadm command fails and :raise_on_err flag is set
+  def racadm_set(fqdd, group, config_object="", params=[], index="", process_opts={})
+    path = "%s.%s.%s" % [fqdd, group, config_object]
+    path << ".%s" % index unless index.to_s.empty?
+    racadm_cmd("set %s" % path, params, process_opts)
   end
 
-  def racadm_get(fqdd, group='', config_object='', index='')
-    path = "#{fqdd}.#{group}.#{config_object}"
-    if(!index.to_s.empty?)
-      path << ".#{index}"
+  # Racadm get command
+  #
+  # Executes desired racadm get command and parses output from the command
+  #
+  # @param fqdd [String] FQDD to be used in racadm set <fqdd>.<group>.<object>.<index>
+  # @param group [String] group to be used in racadm set <fqdd>.<group>.<object>.<index>
+  # @param config_object [String] config to be used in racadm set <fqdd>.<group>.<object>.<index>
+  # @param index [String] index to be used in racadm set <fqdd>.<group>.<object>.<index>
+  # @return [Object] output for the command result. Can be either a string, or list of strings
+  def racadm_get(fqdd, group="", config_object="", index="")
+    path = "%s.%s.%s" % [fqdd, group, config_object]
+    unless index.to_s.empty?
+      path << ".%s" % index
     end
-    cmd = "racadm get #{path}"
+    cmd = "racadm get %s" % path
     parse_output_values(client.exec!(cmd))
   end
 
   def parse_output_values(output)
     lines = output.split("\n")
-    return '' if lines.empty?
+    return "" if lines.empty?
     #First line of idrac racadm returns something like [Key=Foo.Bar.Foobar] which is unnecessary for use in this module
-    lines.shift if lines.first.start_with?('[') && lines.first.end_with?(']')
-    #If we can split by =, it's a return with key/values we can parse.  Otherwise, just return the output as is split by new line character
+    lines.shift if lines.first.start_with?("[") && lines.first.end_with?("]")
+    #If we can split by =, it"s a return with key/values we can parse.  Otherwise, just return the output as is split by new line character
     if(lines.first.split("=").size > 1)
       output = Hash[lines.map{|str| str.split("=")}.collect{|line|
         key = line[0].strip
         #Sometimes, the line starts with # or !!symbol.  Just clean if it does so we return a nice hash
-        if(key.start_with?('#'))
+        if(key.start_with?("#"))
           key = key[1..-1].strip
-        elsif(key.start_with?('!!'))
+        elsif(key.start_with?("!!"))
           key = key[2..-1].strip
         end
         value = line[1].nil? ? "" : line[1].strip

--- a/lib/puppet/provider/server_onboard/default.rb
+++ b/lib/puppet/provider/server_onboard/default.rb
@@ -1,0 +1,118 @@
+# Puppet provider for server on-boarding
+# Copyright (C) 2016 Dell, Inc.
+provider_path = Pathname.new(__FILE__).parent.parent
+require File.join(provider_path, "idrac_racadm")
+require "open3"
+Puppet::Type.type(:server_onboard).provide(:default, :parent => Puppet::Provider::IdracRacadm) do
+
+  # Puppet resource exists method
+  #
+  # Puppet invoked method to indicate whether to invoke create or destroy
+  #
+  # @return [Boolean] indicates whether puppet resource is present or not on target system
+  def exists?
+    false
+  end
+
+  # Puppet resource create method
+  #
+  # Puppet invoked method to create resource for configuring creds and network
+  #
+  # @return [void]
+  # @raise [StandardError] when either credentials or network type cannot be applied
+  def create
+    setup_credential
+    setup_network
+  end
+
+  # Set credential
+  #
+  # sets relevant username, password
+  #
+  # @return [void]
+  # @raise [StandardError] when credentials cannot be applied
+  def setup_credential
+    credential = resource[:credential]
+    if credential.nil? || credential["username"].nil? || credential["password"].nil?
+      raise "username or password not specified"
+    end
+
+    Puppet.debug("Setting credentials for %s" % resource[:name])
+    racadm_set("idrac", "users", "username", credential["username"], "2", :raise_on_err => true)
+    racadm_set("idrac", "users", "password", credential["password"], "2", :raise_on_err => true)
+  end
+
+  # Set network configuration
+  #
+  # sets network configuration values depending on specified network_type.
+  #
+  # @return [void]
+  # @raise [StandardError] when network configuration cannot be applied
+  def setup_network
+    return if resource[:networks].nil?
+
+    network_type = resource[:network_type]
+
+    if network_type.to_s == "static"
+      network_obj = resource[:networks]
+      if network_obj["staticNetworkConfiguration"].nil? || network_obj["staticNetworkConfiguration"].empty?
+        raise "network configuration params are not static"
+      end
+
+      config_static_network network_obj["staticNetworkConfiguration"]
+    end
+  end
+
+  # Set static network config
+  #
+  # sets static network configuration values like static IP settings, DNS settings, etc
+  #
+  # @param config [Hash] static network config to be applied
+  # @option config [String] "ipAddress" static IP address
+  # @option config [String] "subnet" subnet for the static network
+  # @option config [String] "gateway" gateway for the static network
+  # @option config [String] "primaryDns" primary DNS server address
+  # @option config [String] "secondaryDns" secondary DNS server address
+  # @return [void]
+  # @raise [StandardError] when network configuration cannot be applied
+  def config_static_network(config)
+    racadm_set("idrac", "ipv4", "dns1", config["primaryDns"]) if config["primaryDns"]
+    racadm_set("idrac", "ipv4", "dns2", config["secondaryDns"]) if config["secondaryDns"]
+
+    Timeout.timeout(60) do
+      racadm_cmd("setniccfg", ["-s", config["ipAddress"], config["subnet"], config["gateway"]])
+    end
+
+    wait_for_ip(config["ipAddress"])
+  end
+
+  # Wait for given IP
+  #
+  # using wsman command, wait for certain period of time for given IP address
+  #
+  # @param ip [String] IP address to wait on
+  # @param max_wait [Integer] maximum seconds to wait for the IP to connect
+  # @return [void]
+  # @raise [StandardError] when times out waiting for static IP address
+  def wait_for_ip(ip, max_wait=300)
+    current_time = Time.now
+
+    require "asm/wsman"
+    username = resource[:credential]["username"]
+    password = resource[:credential]["password"]
+    wsman = ASM::WsMan.new({:host => ip, :user => username, :password => password})
+
+    # Invoke wsman identify command in a loop until max wait has elapsed or we get output indicating availability
+    while Time.now - current_time < max_wait
+      sleep 10
+      output = wsman.identify(10)
+      if output
+        Puppet.info("IP %s is now available" % ip)
+        return
+      end
+    end
+
+    # If we reach here, it means no confirmation of connectivity
+    raise("Timed out waiting for static IP address to be set for %s" % resource[:name])
+  end
+end

--- a/lib/puppet/type/server_onboard.rb
+++ b/lib/puppet/type/server_onboard.rb
@@ -1,0 +1,62 @@
+Puppet::Type.newtype(:server_onboard) do
+  desc "Puppet type to setup networking and new creds on a server through racadm"
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc "certname of the server"
+  end
+
+  # Credential property
+  #
+  # specify username and password for connecting to server
+  #
+  # @param credential [Hash] Options for specifying the credential
+  #
+  # @option credential [String] "username" username for connecting to the server
+  # @option credential [String] "password" password for connecting to the server
+  #
+  # @example puppet manifest to specify credential
+  #  server_onboard { "rackserver-abcd123" :
+  #    credential = {
+  #      "username" => "foo",
+  #      "password" => "bar"
+  #    }
+  #  }
+  newproperty(:credential) do
+    desc "credential specifying username and password for connecting to the server"
+  end
+
+  # Network Configuration parameter
+  #
+  # specification for network configuration like static IP, DNS settings
+  #
+  # @param networks [Hash] Options for specifying the network config
+  #
+  # @option networks [Boolean] "static" specifies whether config is static or not
+  # @option networks [Hash] "staticNetworkConfiguration" specifies config parameters such as
+  #                          ipAddress, gateway, subnet, primaryDns, secondaryDns
+  #
+  # @example puppet manifest to specify static network config
+  #  server_onboard { "rackserver-abcd123" :
+  #    networks = {
+  #      "static" => true,
+  #      "staticNetworkConfiguration" => {
+  #        "gateway" => "172.27.0.1",
+  #        "subnet" => "255.255.0.0",
+  #        "primaryDns" => null,
+  #        "secondaryDns" => null,
+  #        "ipAddress" => "172.27.15.14"
+  #      }
+  #    }
+  #  }
+  newparam(:networks) do
+    desc "network configuration for setting the idrac networks"
+  end
+
+  newproperty(:network_type) do
+    desc "type of network to setup on the server"
+    newvalue(:static)
+    newvalue(:existing)
+  end
+end

--- a/spec/spec_helper_ext.rb
+++ b/spec/spec_helper_ext.rb
@@ -1,0 +1,6 @@
+require "spec_helper"
+require "mocha/api"
+
+fixture_path = File.expand_path(File.join(__FILE__, "..", "fixtures"))
+# Set module path to locally downloaded modules to fixtures directory
+Puppet[:modulepath] = File.join(fixture_path, "modules")

--- a/spec/unit/puppet/provider/idrac_racadm_spec.rb
+++ b/spec/unit/puppet/provider/idrac_racadm_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper_ext"
+require "rspec/expectations"
+require "puppet/provider/idrac_racadm"
+
+describe Puppet::Provider::IdracRacadm do
+  let(:racadm) { Puppet::Provider::IdracRacadm.new }
+  let(:ssh) { Object.new }
+
+  context "instance validation" do
+    it "should have instance object" do
+      expect(racadm.class).to eq(Puppet::Provider::IdracRacadm)
+    end
+  end
+
+  context "#racadm_cmd" do
+    it "should execute fine for successful command having params" do
+      ssh.stubs(:exec!).with("racadm cmd foo bar").returns("Object executed successfully")
+      racadm.stubs(:client).returns(ssh)
+      expect(racadm.racadm_cmd("cmd", ["foo", "bar"] )).to eq("Object executed successfully")
+    end
+
+    it "should fail when command errors and raise on err is specified" do
+      ssh.stubs(:exec!).returns("ERROR: Something went wrong")
+      racadm.stubs(:client).returns(ssh)
+      expect {racadm.racadm_cmd("cmd", [], :raise_on_err => true)}.to raise_error(/Error in racadm command/)
+    end
+
+    it "should return an array for command that returns multi-line output" do
+      ssh.stubs(:exec!).returns("Result\nGood")
+      racadm.stubs(:client).returns(ssh)
+      expect(racadm.racadm_cmd("cmd", [], :raise_on_err => true)).to eq(["Result", "Good"])
+    end
+  end
+end

--- a/spec/unit/puppet/provider/server_onboard/server_onboard_spec.rb
+++ b/spec/unit/puppet/provider/server_onboard/server_onboard_spec.rb
@@ -1,0 +1,91 @@
+require "spec_helper_ext"
+require "rspec/expectations"
+
+describe Puppet::Type.type(:server_onboard).provider(:default) do
+  let(:resource) { Puppet::Type.type(:server_onboard).new({ :name => "rackserver-ABCD123"}) }
+
+  let(:provider) {resource.provider}
+
+  context "instance validation" do
+    it "should have instance object" do
+      expect(provider.class).to eq(Puppet::Type::Server_onboard::ProviderDefault)
+    end
+  end
+
+  context "set credential" do
+    it "should raise error when credentials are not set" do
+      provider.resource[:credential] = {}
+      expect {provider.setup_credential}.to raise_error(/not specified/)
+    end
+
+    it "should invoke racadm_set commands for specified credentials" do
+      provider.stubs(:racadm_set).with(anything()).returns("Object Executed Successfully")
+      provider.expects(:racadm_set).times(2)
+      provider.resource[:credential] = {"username" => "foo", "password" => "bar"}
+      provider.setup_credential
+    end
+  end
+
+  context "set network type" do
+    before(:each) do
+      provider.stubs(:config_static_network).with(anything())
+    end
+
+    it "should not invoke static config when not specified" do
+      provider.expects(:config_static_network).never
+      provider.resource[:network_type] = "existing"
+      provider.setup_network
+    end
+
+    it "should invoke static config when specified" do
+      provider.expects(:config_static_network).once
+      provider.resource[:networks] = {
+        "staticNetworkConfiguration" => {
+          "ipAddress" => "1.2.3.4", "subnet" => "1.1.0.0", "gateway" => "1.2.0.1" }
+      }
+      provider.resource[:network_type] = "static"
+      provider.setup_network
+    end
+
+    it "should raise error when static type specified without config" do
+      provider.expects(:config_static_network).never
+      provider.resource[:networks] = {}
+      provider.resource[:network_type] = "static"
+      expect {provider.setup_network}.to raise_error(/not static/)
+    end
+  end
+
+  context "set static configuration" do
+    before(:each) do
+      provider.stubs(:racadm_set).with(anything()).returns("Object Executed Successfully")
+      provider.stubs(:racadm_cmd).with(anything()).returns("Object Executed Successfully")
+      provider.stubs(:wait_for_ip).with(anything())
+    end
+
+    it "should set only static IP and not dns configs" do
+      provider.expects(:racadm_set).never
+      provider.expects(:racadm_cmd).once
+      provider.expects(:wait_for_ip).once
+      provider.config_static_network("ipAddress" => "1.2.3.4", "subnet" => "1.1.0.0", "gateway" => "1.2.0.1")
+    end
+
+    it "should set static IP and primary dns" do
+      provider.expects(:racadm_set).once
+      provider.expects(:racadm_cmd).once
+      provider.expects(:wait_for_ip).once
+      provider.config_static_network(
+        "ipAddress" => "1.2.3.4", "subnet" => "1.1.0.0", "gateway" => "1.2.0.1", "primaryDns" => "4.5.6.7"
+      )
+    end
+
+    it "should set static IP and all dsn configs" do
+      provider.expects(:racadm_set).times(2)
+      provider.expects(:racadm_cmd).once
+      provider.expects(:wait_for_ip).once
+      provider.config_static_network(
+        "ipAddress" => "1.2.3.4", "subnet" => "1.1.0.0", "gateway" => "1.2.0.1",
+        "primaryDns" => "4.5.6.7", "secondaryDns" => "8.9.10.11"
+      )
+    end
+  end
+end


### PR DESCRIPTION
Implementation for new type and provider for configuring credentials
and network settings for a given server using racadm commands. We keep
same style of implementation as we did for blades in dell-cmc module,
except for the fact the racadm calls here go directly to the server.
We also clean up and yard doc some execution methods in racadm.rb

Note: Maybe we should later refactor the code to move racadm command
to a common project where eventually all racadm calls for servers go to
single place. Right now some code is unnecessarily duplicated between
racadm.rb in dell-cmc and dell-idrac modules.