### PR TITLE
misc: Fix travis CI problems introduced by dependencies

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,10 +35,10 @@ end
 task :default => :spec
 
 begin
-  if Gem::Specification::find_by_name('puppet-lint')
-    require 'puppet-lint/tasks/puppet-lint'
+  if Gem::Specification::find_by_name("puppet-lint")
+    require "puppet-lint/tasks/puppet-lint"
     PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "vendor/**/*.pp"]
-    task :default => [:rspec, :lint]
+    task :default => [:spec, :lint]
   end
 rescue Gem::LoadError
 end


### PR DESCRIPTION
Seems recent changes in a dependent project triggered puppet-lint gem to be
installed and task as a result invoke rspec task which is expected not
to work. We fix this problem by using "spec" task for pupet-lint gem