### PR TITLE
ASM-8257 iDRAC configuation failing for VSAN and SD card deployments

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -1054,7 +1054,7 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
   end
 
   def non_raid_not_requested?
-    vds = @resource["raid_configuration"]["virtualDisks"]
+    vds = (@resource["raid_configuration"] || {})["virtualDisks"]
     return false unless vds
     !!vds.find { |vd| vd["raidLevel"] == "nonraid" }
   end


### PR DESCRIPTION
With recent changes for converting the non-RAID disk to RAID mode, VSAN and SD card deployment got broken as there is no raid_confiuraiton parameter in the asm::idrac resource