### PR TITLE
ASM-8239 Fix Net::SSH::HostKeyMismatch in racadm transport

### DIFF
--- a/lib/puppet_x/puppetlabs/transport/racadm.rb
+++ b/lib/puppet_x/puppetlabs/transport/racadm.rb
@@ -18,7 +18,8 @@ module PuppetX::Puppetlabs::Transport
       i = 0
       begin
         port = @options[:port] ? @options[:port] : 22
-        @ssh = Net::SSH.start(@options[:host], @options[:user], {:port => port, :password => @options[:password]})
+        @ssh = Net::SSH.start(@options[:host], @options[:user], :port => port, :password => @options[:password],
+                              :paranoid => Net::SSH::Verifiers::Null.new)
       rescue => e
         i += 1
          if i < 4


### PR DESCRIPTION
We set paranoid param in other transport modules dealing with SSH to
ensure not getting cert errors on servers when something on server
changes. Seems this transport did not have the same paranoid param.