### PR TITLE
ASM-8438 ImportSystemConfig runs forever

### DIFF
--- a/lib/puppet/provider/importsystemconfiguration/default.rb
+++ b/lib/puppet/provider/importsystemconfiguration/default.rb
@@ -63,6 +63,7 @@ Puppet::Type.type(:importsystemconfiguration).provide(
     Puppet::Idrac::Util.wait_or_clear_running_jobs
     attempts = 0
     begin
+      obj.attempt = attempts
       obj.importtemplatexml
     rescue Puppet::Idrac::ConfigError => e
       attempts += 1


### PR DESCRIPTION
Even though we were doing a lookup on the current HDDSeq and
BIOSBootSeq (not using the export xml)  We were only generating
the config xml one time.  Not we will regenerate the config xml
on every importsystemconfig run and rotate the old config (should
only be max of 3)