### PR TITLE
ASM-8438 Do not set existing Hdd or BiosBoot seq

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -28,6 +28,7 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
   end
 
   def importtemplatexml
+    reset_xml_base
     munge_config_xml
     execute_import
   end
@@ -281,6 +282,10 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
     suffix = sata_disks.sort.first.split('-')
     disk_name = ('A'..'Z').to_a[suffix[0].to_i]
     "Disk.SATAEmbedded.%s-%s" % [ disk_name, '1' ]
+  end
+
+  def reset_xml_base
+    @xml_base = nil
   end
 
   def xml_base


### PR DESCRIPTION
iDrac versions before 2.40.40.40 had a bug where if the HddSeq or
BiosBootSeq is set but not changed from it's current value the
resulting ImportSystemConfiguration job will run forever. The
workaround is to not pass those values if no change is
required. Various fixes have been put in for this issue but problems
keep cropping back up -- the whole importsystemconfiguration flow
needs a rework.

The current problem arises because the importsystemconfiguration
provider reuses the same Importtemplatexml object to retry the
ImportSystemConfiguration if it fails the first time. In that case
xml_base will be set to the XML that was applied in the first pass
rather than the original iDrac system configuration as seen from
ExportSystemConfiguration. Because of that it could contain HddSeq or
BiosBootSeq values that the various workarounds wouldn't "see". The
result would be that the code still might set a HddSeq or BiosBootSeq
to a pre-existing value and trigger the bug. The fix this time around
is to reset xml_base back to the original exported value prior to
beginning a new import.