### PR TITLE
ASM-8438, ASM-8545 Wait for failed import jobs to complete

### DIFF
--- a/spec/unit/puppet/provider/checkjdstatus_spec.rb
+++ b/spec/unit/puppet/provider/checkjdstatus_spec.rb
@@ -3,65 +3,68 @@ require "puppet/provider/checkjdstatus"
 require "asm/wsman"
 
 describe Puppet::Provider::Checkjdstatus do
-  let(:check_jd_status) { Puppet::Provider::Checkjdstatus.new("172.17.9.172",
-                                                              "root",
-                                                              "calvin",
-                                                              "JID_621911093617") }
+  let(:job_id) { "JID_621911093617" }
+  let(:wsman) { stub("mock wsman") }
+  let(:endpoint) { {:host => "172.17.9.172", :user => "root", :password => "calvin" } }
+  let(:check_jd_status) { Puppet::Provider::Checkjdstatus.new(endpoint[:host], endpoint[:user], endpoint[:password], job_id) }
+
   it "should be a provider" do
     check_jd_status.should be_kind_of(Puppet::Provider::Checkjdstatus)
   end
 
   it "has class variables" do
-    check_jd_status.instance_variable_get(:@ip).should eql("172.17.9.172")
-    check_jd_status.instance_variable_get(:@username).should eql("root")
-    check_jd_status.instance_variable_get(:@password).should eql("calvin")
-    check_jd_status.instance_variable_get(:@instanceid).should eql("JID_621911093617")
-  end
-
-  it "should ASM::WsMan.invoke with initalized variables" do
-    ASM::WsMan.should_receive(:invoke).with({:host => "172.17.9.172", :user => "root", :password => "calvin"},
-                                            "get",
-                                            "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/root/dcim/DCIM_LifecycleJob?InstanceID=JID_621911093617",
-                                            :logger => Puppet,
-                                            :selector => ["//n1:JobStatus", "//n1:Message", "//n1:MessageID"]
-    ).once.and_return(["Completed",
-                       "Successfully exported system configuration XML file.",
-                       "SYS043"])
-    check_jd_status.checkjdstatus.should == "Completed"
+    check_jd_status.instance_variable_get(:@ip).should eql(endpoint[:host])
+    check_jd_status.instance_variable_get(:@username).should eql(endpoint[:user])
+    check_jd_status.instance_variable_get(:@password).should eql(endpoint[:password])
+    check_jd_status.instance_variable_get(:@instanceid).should eql(job_id)
   end
 
   it "should return job_status when successful" do
-    ASM::WsMan.should_receive(:invoke).once.and_return(["Completed", "Successfully exported system configuration XML file.", "SYS043"])
+    ASM::WsMan.should_receive(:new).with(endpoint, :logger => Puppet).once.and_return(wsman)
+    wsman.should_receive(:get_lc_job).with(job_id)
+        .once.and_return(:job_status => "Completed", :message => "Successfully exported system configuration XML file.", :message_id => "SYS043")
     check_jd_status.checkjdstatus.should == "Completed"
   end
 
   it "should return SYS051 when message_id is SYS051" do
-    ASM::WsMan.should_receive(:invoke).once.and_return(["", "", "SYS051"])
+    ASM::WsMan.should_receive(:new).with(endpoint, :logger => Puppet).once.and_return(wsman)
+    wsman.should_receive(:get_lc_job).with(job_id).once.and_return(:message_id => "SYS051")
     check_jd_status.checkjdstatus.should == "SYS051"
   end
 
   it "should return LC068 message_id is LC068" do
-    ASM::WsMan.should_receive(:invoke).once.and_return(["", "", "LC068"])
+    ASM::WsMan.should_receive(:new).with(endpoint, :logger => Puppet).once.and_return(wsman)
+    wsman.should_receive(:get_lc_job).with(job_id).once.and_return(:message_id => "LC068")
     check_jd_status.checkjdstatus.should == "LC068"
   end
 
-  it "should return Failed if job_status is completed with errors" do
-    ASM::WsMan.should_receive(:invoke).once.and_return(["completed with errors", "", ""])
+  it "should return Failed if job_status is completed with errors and 100% complete" do
+    ASM::WsMan.should_receive(:new).with(endpoint, :logger => Puppet).once.and_return(wsman)
+    wsman.should_receive(:get_lc_job).with(job_id).once.and_return(:job_status => "completed with errors", :percent_complete => "100")
     check_jd_status.checkjdstatus.should == "Failed"
   end
 
-  it "should return Failed if job_message is completed with errors" do
-    ASM::WsMan.should_receive(:invoke).once.and_return(["", "completed with errors", ""])
+  it "should return Failed if job_message is completed with errors and 100% complete" do
+    ASM::WsMan.should_receive(:new).with(endpoint, :logger => Puppet).once.and_return(wsman)
+    wsman.should_receive(:get_lc_job).with(job_id).once.and_return(:message => "completed with errors", :percent_complete => "100")
     check_jd_status.checkjdstatus.should == "Failed"
+  end
+
+  it "should return job_status if failed but not 100% complete" do
+    ASM::WsMan.should_receive(:new).with(endpoint, :logger => Puppet).once.and_return(wsman)
+    wsman.should_receive(:get_lc_job).with(job_id).once.and_return(:job_status => "Running")
+    check_jd_status.checkjdstatus.should == "Running"
   end
 
   it "should raise an error when job_status is an empty string" do
-    ASM::WsMan.should_receive(:invoke).once.and_return(["", "", ""])
+    ASM::WsMan.should_receive(:new).with(endpoint, :logger => Puppet).once.and_return(wsman)
+    wsman.should_receive(:get_lc_job).with(job_id).once.and_return(:job_status => "")
     expect { check_jd_status.checkjdstatus }.to raise_error(RuntimeError, "Job ID not created")
   end
 
   it "should raise an error when job_status is nil" do
-    ASM::WsMan.should_receive(:invoke).once.and_return([nil, "", ""])
+    ASM::WsMan.should_receive(:new).with(endpoint, :logger => Puppet).once.and_return(wsman)
+    wsman.should_receive(:get_lc_job).with(job_id).once.and_return(:job_status => "")
     expect { check_jd_status.checkjdstatus }.to raise_error(RuntimeError, "Job ID not created")
   end
 

--- a/spec/unit/puppet/provider/importtemplatexml_spec.rb
+++ b/spec/unit/puppet/provider/importtemplatexml_spec.rb
@@ -268,15 +268,21 @@ describe Puppet::Provider::Importtemplatexml do
 
   context "when exporting template" do
     it "should get Job id for Export template xml" do
+      Puppet::Idrac::Util.should_receive(:wait_for_lc_ready).once
+
       @fixture.should_receive(:execute_import).once.and_return('JID_896466295795')
       @fixture.stub(:munge_config_xml)
+
       jobid = @fixture.importtemplatexml
       jobid.should == "JID_896466295795"
     end
 
     it "should not get Job id if import template fail" do
+      Puppet::Idrac::Util.should_receive(:wait_for_lc_ready).once
+
       ASM::WsMan.should_receive(:invoke).once.and_return(nil)
       @fixture.stub(:munge_config_xml)
+
       expect { @fixture.importtemplatexml }.to raise_error("ImportSystemConfiguration Job could not be created:  Response is invalid")
     end
   end


### PR DESCRIPTION
Existing ImportSystemConfiguration job polling would exit early
(before the job says that it is 100% complete) in the case of
failure. Because of that and the fact that Importtemplatexml did not
wait for LC ready prior to cacluating the configuration to apply it
was possible that a previous ImportSystemConfiguration job was in
progress when a new import was begun. Therefore code that was
checking iDrac inventory might be getting values that would change
as the result of a previously running job. This could lead to the
dreaded "ImportSystemConfiguration job runs forever" bug which
happens in iDrac prior to 2.40.40.40 when a BiosBootSeq or HddSeq
is set to a pre-existing value (i.e. not changed).

This commit attempts to fix this by:

- waiting for LC ready prior to calculating the configuration to
  apply

- waiting for failed jobs to report 100% complete

- waiting for LC ready after all failed import jobs