### PR TITLE
ASM-6823 Ability to place Raid Mode into pass-through with Hardware configuration only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,8 @@ end
 
 group :development, :test do
   gem 'rake'
-  gem 'rspec'
-  gem 'puppetlabs_spec_helper'
+  gem 'rspec', '~>3.4.0', :require => false
+  gem 'puppetlabs_spec_helper', '0.4.1', :require => false
   gem 'json_pure', '2.0.1'
   if puppetversion = ENV['PUPPET_GEM_VERSION']
     gem 'puppet', puppetversion

--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -580,7 +580,7 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
             disk_types[fqdd] = type
           end
 
-          if unprocessed.nil? && @boot_device.match(/VSAN/i)
+          if (unprocessed.nil? || unprocessed.empty?) && @boot_device.match(/VSAN/i)
             disk_types.keys.each do |disk|
               controller = disk.split(':').last
               raid_configuration[controller][:hotspares] << disk


### PR DESCRIPTION
For VSAN deployment of SD card, HBA mode configuration was getting skipped as empty RAID configuration is passed from asm-deployer