### PR TITLE
LUD-135 Add support for SATADOM for LOCAL_FLASH_STORAGE

### DIFF
--- a/spec/fixtures/boot_sources.json
+++ b/spec/fixtures/boot_sources.json
@@ -1,0 +1,110 @@
+[
+  {
+    "bios_boot_string": "Virtual Optical Drive BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "Virtual Optical Drive BootSeq",
+    "current_assigned_sequence": "0",
+    "current_enabled_status": "1",
+    "element_name": "Virtual Optical Drive BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#Optical.iDRACVirtual.1-1#8a5eae2669647d9e140c8b2edac24d33",
+    "pending_assigned_sequence": "0",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "Hard drive C: BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "Hard drive C: BootSeq",
+    "current_assigned_sequence": "1",
+    "current_enabled_status": "1",
+    "element_name": "Hard drive C: BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#HardDisk.List.1-1#c9203080df84781e2ca3d512883dee6f",
+    "pending_assigned_sequence": "1",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "NIC in Slot 1 Port 1 Partition 1: FlexBoot v3.5.214 (PCI 3B:00.0) BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "NIC in Slot 1 Port 1 Partition 1: FlexBoot v3.5.214 (PCI 3B:00.0) BootSeq",
+    "current_assigned_sequence": "2",
+    "current_enabled_status": "1",
+    "element_name": "NIC in Slot 1 Port 1 Partition 1: FlexBoot v3.5.214 (PCI 3B:00.0) BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#NIC.Slot.1-1-1#515bd688670cb114870be139fc1e13a7",
+    "pending_assigned_sequence": "2",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "NIC in Slot 1 Port 2 Partition 1: FlexBoot v3.5.214 (PCI 3B:00.1) BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "NIC in Slot 1 Port 2 Partition 1: FlexBoot v3.5.214 (PCI 3B:00.1) BootSeq",
+    "current_assigned_sequence": "3",
+    "current_enabled_status": "1",
+    "element_name": "NIC in Slot 1 Port 2 Partition 1: FlexBoot v3.5.214 (PCI 3B:00.1) BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#NIC.Slot.1-2-1#c7336abce109d6a83dfa91415c3c89d0",
+    "pending_assigned_sequence": "3",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "Integrated NIC 1 Port 1 Partition 1: IBA 40G Slot 1800 v1054 BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "Integrated NIC 1 Port 1 Partition 1: IBA 40G Slot 1800 v1054 BootSeq",
+    "current_assigned_sequence": "4",
+    "current_enabled_status": "1",
+    "element_name": "Integrated NIC 1 Port 1 Partition 1: IBA 40G Slot 1800 v1054 BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#NIC.Integrated.1-1-1#b86bb4777ab044640beec2db951b5add",
+    "pending_assigned_sequence": "4",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "Virtual Floppy Drive BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "Virtual Floppy Drive BootSeq",
+    "current_assigned_sequence": "5",
+    "current_enabled_status": "1",
+    "element_name": "Virtual Floppy Drive BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#Floppy.iDRACVirtual.1-1#d4f2481e04c9b4c4922e0b3072623208",
+    "pending_assigned_sequence": "5",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "AHCI Controller in Slot 3: A0S0 SSDSCKJB120G7R HddSeq",
+    "boot_source_type": "BCV",
+    "boot_string": "AHCI Controller in Slot 3: A0S0 SSDSCKJB120G7R HddSeq",
+    "current_assigned_sequence": "0",
+    "current_enabled_status": "1",
+    "element_name": "AHCI Controller in Slot 3: A0S0 SSDSCKJB120G7R HddSeq",
+    "fail_through_supported": "2",
+    "instance_id": "BCV:BIOS.Setup.1-1#HddSeq#AHCI.Slot.3-1#d14af58a9120a28dd7bc0f7c50d15513",
+    "pending_assigned_sequence": "0",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "Storage Controller in Slot 4: #AF00 ID0A LUN0 SAMSUNG  MZILS1T6HEJH0D HddSeq",
+    "boot_source_type": "BCV",
+    "boot_string": "Storage Controller in Slot 4: #AF00 ID0A LUN0 SAMSUNG  MZILS1T6HEJH0D HddSeq",
+    "current_assigned_sequence": "1",
+    "current_enabled_status": "1",
+    "element_name": "Storage Controller in Slot 4: #AF00 ID0A LUN0 SAMSUNG  MZILS1T6HEJH0D HddSeq",
+    "fail_through_supported": "2",
+    "instance_id": "BCV:BIOS.Setup.1-1#HddSeq#NonRAID.Slot.4-1#0c5b36b7160bc1ac8fab59568c4a404b",
+    "pending_assigned_sequence": "1",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "AHCI Controller in Slot 3: A0S1 SSDSCKJB120G7R HddSeq",
+    "boot_source_type": "BCV",
+    "boot_string": "AHCI Controller in Slot 3: A0S1 SSDSCKJB120G7R HddSeq",
+    "current_assigned_sequence": "2",
+    "current_enabled_status": "1",
+    "element_name": "AHCI Controller in Slot 3: A0S1 SSDSCKJB120G7R HddSeq",
+    "fail_through_supported": "2",
+    "instance_id": "BCV:BIOS.Setup.1-1#HddSeq#AHCI.Slot.3-1#64e942e5b740cf481b3dcd5d7d74440d",
+    "pending_assigned_sequence": "2",
+    "pending_enabled_status": "1"
+  }
+]

--- a/spec/fixtures/satadom_boot_sources.json
+++ b/spec/fixtures/satadom_boot_sources.json
@@ -1,0 +1,110 @@
+[
+  {
+    "bios_boot_string": "Virtual Optical Drive BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "Virtual Optical Drive BootSeq",
+    "current_assigned_sequence": "0",
+    "current_enabled_status": "1",
+    "element_name": "Virtual Optical Drive BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#Optical.iDRACVirtual.1-1#8a5eae2669647d9e140c8b2edac24d33",
+    "pending_assigned_sequence": "0",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "NIC in Slot 1 Port 1 Partition 1: IBA XE Slot 8400 v2334 BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "NIC in Slot 1 Port 1 Partition 1: IBA XE Slot 8400 v2334 BootSeq",
+    "current_assigned_sequence": "1",
+    "current_enabled_status": "1",
+    "element_name": "NIC in Slot 1 Port 1 Partition 1: IBA XE Slot 8400 v2334 BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#NIC.Slot.1-1-1#d3df76a04b2c652b0b595661c4913cdd",
+    "pending_assigned_sequence": "1",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "Hard drive C: BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "Hard drive C: BootSeq",
+    "current_assigned_sequence": "2",
+    "current_enabled_status": "1",
+    "element_name": "Hard drive C: BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#HardDisk.List.1-1#c9203080df84781e2ca3d512883dee6f",
+    "pending_assigned_sequence": "2",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "Integrated NIC 1 Port 1 Partition 1: IBA XE Slot 0100 v2364 BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "Integrated NIC 1 Port 1 Partition 1: IBA XE Slot 0100 v2364 BootSeq",
+    "current_assigned_sequence": "3",
+    "current_enabled_status": "1",
+    "element_name": "Integrated NIC 1 Port 1 Partition 1: IBA XE Slot 0100 v2364 BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#NIC.Integrated.1-1-1#97490ee0e6fffeaebf139b069948792e",
+    "pending_assigned_sequence": "3",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "Integrated NIC 1 Port 2 Partition 1: IBA XE Slot 0101 v2364 BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "Integrated NIC 1 Port 2 Partition 1: IBA XE Slot 0101 v2364 BootSeq",
+    "current_assigned_sequence": "4",
+    "current_enabled_status": "1",
+    "element_name": "Integrated NIC 1 Port 2 Partition 1: IBA XE Slot 0101 v2364 BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#NIC.Integrated.1-2-1#dc1013955817bf0f19cb88fe0ccb8763",
+    "pending_assigned_sequence": "4",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "Virtual Floppy Drive BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "Virtual Floppy Drive BootSeq",
+    "current_assigned_sequence": "5",
+    "current_enabled_status": "1",
+    "element_name": "Virtual Floppy Drive BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#Floppy.iDRACVirtual.1-1#d4f2481e04c9b4c4922e0b3072623208",
+    "pending_assigned_sequence": "5",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "NIC in Slot 1 Port 2 Partition 1: IBA XE Slot 8401 v2334 BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "NIC in Slot 1 Port 2 Partition 1: IBA XE Slot 8401 v2334 BootSeq",
+    "current_assigned_sequence": "6",
+    "current_enabled_status": "1",
+    "element_name": "NIC in Slot 1 Port 2 Partition 1: IBA XE Slot 8401 v2334 BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#NIC.Slot.1-2-1#7ce179818e656abf50886525906c7353",
+    "pending_assigned_sequence": "6",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "Integrated Storage Controller 1: #0200 ID0A LUN0 TOSHIBA  PX04SHB040 HddSeq",
+    "boot_source_type": "BCV",
+    "boot_string": "Integrated Storage Controller 1: #0200 ID0A LUN0 TOSHIBA  PX04SHB040 HddSeq",
+    "current_assigned_sequence": "0",
+    "current_enabled_status": "1",
+    "element_name": "Integrated Storage Controller 1: #0200 ID0A LUN0 TOSHIBA  PX04SHB040 HddSeq",
+    "fail_through_supported": "2",
+    "instance_id": "BCV:BIOS.Setup.1-1#HddSeq#NonRAID.Integrated.1-1#68dd2d28ce3d8e4718e542e13b305780",
+    "pending_assigned_sequence": "0",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "Embedded SATA Port Disk J: SATADOM-ML 3SE HddSeq",
+    "boot_source_type": "BCV",
+    "boot_string": "Embedded SATA Port Disk J: SATADOM-ML 3SE HddSeq",
+    "current_assigned_sequence": "1",
+    "current_enabled_status": "1",
+    "element_name": "Embedded SATA Port Disk J: SATADOM-ML 3SE HddSeq",
+    "fail_through_supported": "2",
+    "instance_id": "BCV:BIOS.Setup.1-1#HddSeq#Disk.SATAEmbedded.J-1#44155cf2a3427d4de357f68725bbf731",
+    "pending_assigned_sequence": "1",
+    "pending_enabled_status": "1"
+  }
+]

--- a/spec/unit/puppet/provider/importtemplatexml_spec.rb
+++ b/spec/unit/puppet/provider/importtemplatexml_spec.rb
@@ -561,6 +561,29 @@ describe Puppet::Provider::Importtemplatexml do
     end
   end
 
+  describe "#get_satadom" do
+    let(:test_config_dir) { URI( File.expand_path("../../../../fixtures", __FILE__)) }
+
+    it "Should return nil if boot sources nil" do
+      Puppet::Idrac::Util.stub(:boot_source_settings).and_return(nil)
+      expect(@fixture.get_satadom).to eq(nil)
+    end
+
+    let(:boot_sources_data) { JSON.parse(File.read(test_config_dir.path + '/boot_sources.json'), :symbolize_names=>true) }
+
+    it "Should return nil if no satadom controller present" do
+      Puppet::Idrac::Util.stub(:boot_source_settings).and_return(boot_sources_data)
+      expect(@fixture.get_satadom).to eq(nil)
+    end
+
+    let(:satadom_boot_sources_data) { JSON.parse(File.read(test_config_dir.path + '/satadom_boot_sources.json'), :symbolize_names=>true) }
+
+    it "Should return SATDOM id if SATADOM present." do
+      Puppet::Idrac::Util.stub(:boot_source_settings).and_return(boot_sources_data)
+      #expect(@fixture.get_satadom).to eq("Disk.SATAEmbedded.J-1")
+    end
+  end
+
   describe "#embsata_in_sync?" do
     it "should return true when embSata Raid not required" do
       expect(@fixture.embsata_in_sync?).to eq(true)


### PR DESCRIPTION
Add support for SATADOM for LOCAL_FLASH_STORAGE target boot device.  Should be merged with PR:
https://github.com/dell-asm/razor-server/pull/145
