### PR TITLE
LUD-534 Fixed bug where removing nonraid disks

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -588,7 +588,7 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
     # Check that any non-raid virtual disks are being requested on a controller that supports configuration.
     # Currently only the HBA330 Mini does not support configuration and should already be in non-raid
     # mode.
-    unless @resource[:raid_configuration].nil? || @resource[:raid_configuration][:virtualDisks].nil?
+    unless @resource[:raid_configuration].nil? || @resource[:raid_configuration]["virtualDisks"].nil?
       @resource[:raid_configuration]["virtualDisks"].each do |this_virtual_disk|
         if this_virtual_disk["raidLevel"] == "nonraid"
           if !controller_supports_non_raid?(this_virtual_disk["controller"])


### PR DESCRIPTION
Fixed bug where removing nonraid disks was not happening for nonRAID controllers that don't
support it.