### PR TITLE
VXFM-4166 Skip NVMe drives without controllers

### DIFF
--- a/spec/unit/puppet/provider/importtemplatexml_spec.rb
+++ b/spec/unit/puppet/provider/importtemplatexml_spec.rb
@@ -950,4 +950,27 @@ EOF
     end
   end
 
+  describe "#controller_supports_non_raid?" do
+    let(:controllers) do
+      [{:fqdd => "NonRAID.Slot.2-1", :product_name => "Dell PERC H730"},
+       {:fqdd => "NonRAID.Slot.3-1", :product_name => "Dell HBA330 Adp"}]
+    end
+
+    before(:each) do
+      @fixture.should_receive(:disk_controllers).once.and_return(controllers)
+    end
+
+    it "should return false for HBA330" do
+      expect(@fixture.controller_supports_non_raid?("NonRAID.Slot.3-1")).to eq(false)
+    end
+
+    it "should return false for NVMe drives (no controller)" do
+      expect(@fixture.controller_supports_non_raid?("Enclosure.Internal.0-1")).to eq(false)
+    end
+
+    it "should return true for anything else" do
+      expect(@fixture.controller_supports_non_raid?("NonRAID.Slot.2-1")).to eq(true)
+    end
+  end
+
 end


### PR DESCRIPTION
NVMe drives may be connected directly to the PCIe bus without a
controller. However, they are passed in the `raid_configuration` with
a "fake" controller value of "Enclosure.Internal.0-1" in the
`virtualDisks` list:

    raid_configuration:
      virtualDisks:
      - raidLevel: nonraid
        physicalDisks:
        - Disk.Bay.21:Enclosure.Internal.0-1
        - Disk.Bay.22:Enclosure.Internal.0-1
        - Disk.Bay.23:Enclosure.Internal.0-1
        controller: Enclosure.Internal.0-1
        configuration:
          id: 94e9ea6e-80a6-4bc1-be69-541334a30e84
          raidlevel: nonraid
          comparator: minimum
          numberofdisks: 3
          disktype: requirenvme
          controllerFqdd: Enclosure.Internal.0-1
        mediaType: NVMe

In this case they need to be skipped in the same way as
HBA330-attached disks -- they require no configuration.