### PR TITLE
VXFM-5226 Fail ImportSystemConfiguration if it times out

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -138,7 +138,7 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
     timed_out = true
     raise "Import System Configuration is still running."
   ensure
-    return if timed_out
+    raise $! if timed_out
 
     begin
       # After ImportSystemConfiguration completes iDrac will automatically kick off an


### PR DESCRIPTION
Previous code had an ensure block that accidentally ate the exception
if the ImportSystemConfiguration job timed out.