### PR TITLE
VXFM-5951 Need to sanitize NVDIMMs during new deployment

### DIFF
--- a/lib/puppet/provider/idrac.rb
+++ b/lib/puppet/provider/idrac.rb
@@ -64,6 +64,7 @@ class Puppet::Provider::Idrac <  Puppet::Provider
       in_sync &= check_removes(fqdd, children, "/SystemConfiguration", xml_base, "Component")
     end
     in_sync &= import_obj.raid_in_sync?(xml_base, true) if in_sync
+    in_sync &= import_obj.nvdimm_attrs_in_sync? if in_sync
     in_sync
   end
 

--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -280,6 +280,11 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
         changes["partial"]["BIOS.Setup.1-1"]["BootMode"] = "Bios"
       end
     end
+
+    unless nvdimm_attrs_in_sync?
+      changes["partial"]["BIOS.Setup.1-1"]["NvdimmFactoryDefault"] = "NvdimmFactoryDefaultEnable"
+    end
+
     changes
   end
 
@@ -838,6 +843,12 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
 
     Puppet.info("RAID configuration does not need to be updated.")
     true
+  end
+
+  def nvdimm_attrs_in_sync?
+    mem_view = wsman.memory_views
+    nvdimms = mem_view.select {|mem| mem[:rank] == "1" }
+    nvdimms.empty? ? true: false
   end
 
   def get_iscsi_network(network_objects)


### PR DESCRIPTION
In case of NVDIMM on server, then we need to set attribute on BIOS section to enable sanitize NVDIMMs