### PR TITLE
VXFM-8464 Make changes to support raid boot for nodes in a deployment

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -705,7 +705,7 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
             changes['whole'][raids.first] = { 'CurrentControllerMode' => "RAID" }
           end
         end
-        changes['partial'] = {'BIOS.Setup.1-1'=> {'HddSeq' => raid_configuration.keys.first}} if @boot_device =~ /HD/i
+        changes['partial'] = {'BIOS.Setup.1-1'=> {'HddSeq' => raid_configuration.keys.first}} if @boot_device =~ /HD/i && @boot_mode == 'BIOS_MODE'
         unless raid_in_sync?(target_current_xml, true)
           #Getting the first key should get the first internal disk controller, or the first external if no internal on the server
           vd_index = 0

--- a/spec/unit/puppet/provider/importtemplatexml_spec.rb
+++ b/spec/unit/puppet/provider/importtemplatexml_spec.rb
@@ -768,6 +768,7 @@ EOF
       end
 
       it "should return the correct hash" do
+        @fixture.instance_variable_set(:@boot_mode, 'BIOS_MODE')
         raid_changes = @fixture.get_raid_config_changes(@fixture.xml_base)
 
         expected_changes = {
@@ -817,6 +818,7 @@ EOF
       end
 
       it "should return the correct hash" do
+        @fixture.instance_variable_set(:@boot_mode, 'BIOS_MODE')
         raid_changes = @fixture.get_raid_config_changes(@fixture.xml_base)
 
         expected_changes = {
@@ -894,6 +896,7 @@ EOF
       end
 
       it "should return the correct hash" do
+        @fixture.instance_variable_set(:@boot_mode, 'BIOS_MODE')
         raid_changes = @fixture.get_raid_config_changes(@fixture.xml_base)
 
         expected_changes = {


### PR DESCRIPTION
This line was creating problems in the idrac config file causing deployments to fail because it was setting a bad value for hddseq as thats already set with pxe_boot options

Requires Merging from these PR's at same time:
https://github.com/dell-asm/dell-asm-util/pull/158
https://github.com/dell-asm/asm-deployer/pull/3145
https://github.com/dell-asm/asm-core/pull/5433