### PR TITLE
VXFM-9100 Automated iDrac reset was failing due to Net::SSH changes

### DIFF
--- a/lib/puppet/idrac/util.rb
+++ b/lib/puppet/idrac/util.rb
@@ -166,7 +166,7 @@ module Puppet
         Net::SSH.start( transport[:host],
                         transport[:user],
                         :password => transport[:password],
-                        :paranoid => Net::SSH::Verifiers::Null.new,
+                        :verify_host_key => false,
                         :global_known_hosts_file=>"/dev/null" ) do |ssh|
           ssh.exec "racadm racreset soft" do |ch, stream, data|
             Puppet.debug(data)

--- a/lib/puppet_x/puppetlabs/transport/racadm.rb
+++ b/lib/puppet_x/puppetlabs/transport/racadm.rb
@@ -19,7 +19,7 @@ module PuppetX::Puppetlabs::Transport
       begin
         port = @options[:port] ? @options[:port] : 22
         @ssh = Net::SSH.start(@options[:host], @options[:user], :port => port, :password => @options[:password],
-                              :paranoid => Net::SSH::Verifiers::Null.new)
+                              :verify_host_key => false)
       rescue => e
         i += 1
          if i < 4


### PR DESCRIPTION
`Net::SSH::Verifiers::Null` was removed. It looks like
`:verify_host_key => :never` is the more correct way to disable host
key verification but for Dacite release sticking with
`:verify_host_key => false` which is already in use in existing code.