### PR TITLE
VXFM-9988 new sata dom returned different device string

### DIFF
--- a/lib/puppet/provider/importtemplatexml.rb
+++ b/lib/puppet/provider/importtemplatexml.rb
@@ -310,11 +310,9 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
 
   def get_boot_sata_disk
     # If we find a SATADOM device, prefer it, else fallback to getting first SATA disk
-    boot_sources = Puppet::Idrac::Util.boot_source_settings
-    satadom_instance_id = boot_sources.select {|d| d[:boot_string] =~ /SATADOM/}[0][:instance_id] rescue nil
-    if satadom_instance_id
-      Puppet.debug("Prefering SATADOM disk for booting")
-      satadom_instance_id.split("#")[2]
+    sata_disk = get_satadom
+    if sata_disk
+      sata_disk
     else
       get_first_sata_disk
     end
@@ -1164,7 +1162,7 @@ class Puppet::Provider::Importtemplatexml <  Puppet::Provider
 
   def get_satadom
     boot_sources = Puppet::Idrac::Util.boot_source_settings
-    satadom_instance_id = boot_sources.select {|d| d[:boot_string] =~ /SATADOM/}[0][:instance_id] rescue nil
+    satadom_instance_id = boot_sources.select {|d| d[:boot_string] =~ /SATADOM/ || d[:boot_string] =~ /Embedded SATA Port Disk [A-Z]/}[0][:instance_id] rescue nil
     unless satadom_instance_id.nil?
       satadom_instance_id.split("#")[2]
     end

--- a/spec/fixtures/satadom_boot_sources_1.json
+++ b/spec/fixtures/satadom_boot_sources_1.json
@@ -1,0 +1,110 @@
+[
+  {
+    "bios_boot_string": "Virtual Optical Drive BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "Virtual Optical Drive BootSeq",
+    "current_assigned_sequence": "0",
+    "current_enabled_status": "1",
+    "element_name": "Virtual Optical Drive BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#Optical.iDRACVirtual.1-1#8a5eae2669647d9e140c8b2edac24d33",
+    "pending_assigned_sequence": "0",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "NIC in Slot 1 Port 1 Partition 1: IBA XE Slot 8400 v2334 BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "NIC in Slot 1 Port 1 Partition 1: IBA XE Slot 8400 v2334 BootSeq",
+    "current_assigned_sequence": "1",
+    "current_enabled_status": "1",
+    "element_name": "NIC in Slot 1 Port 1 Partition 1: IBA XE Slot 8400 v2334 BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#NIC.Slot.1-1-1#d3df76a04b2c652b0b595661c4913cdd",
+    "pending_assigned_sequence": "1",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "Hard drive C: BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "Hard drive C: BootSeq",
+    "current_assigned_sequence": "2",
+    "current_enabled_status": "1",
+    "element_name": "Hard drive C: BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#HardDisk.List.1-1#c9203080df84781e2ca3d512883dee6f",
+    "pending_assigned_sequence": "2",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "Integrated NIC 1 Port 1 Partition 1: IBA XE Slot 0100 v2364 BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "Integrated NIC 1 Port 1 Partition 1: IBA XE Slot 0100 v2364 BootSeq",
+    "current_assigned_sequence": "3",
+    "current_enabled_status": "1",
+    "element_name": "Integrated NIC 1 Port 1 Partition 1: IBA XE Slot 0100 v2364 BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#NIC.Integrated.1-1-1#97490ee0e6fffeaebf139b069948792e",
+    "pending_assigned_sequence": "3",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "Integrated NIC 1 Port 2 Partition 1: IBA XE Slot 0101 v2364 BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "Integrated NIC 1 Port 2 Partition 1: IBA XE Slot 0101 v2364 BootSeq",
+    "current_assigned_sequence": "4",
+    "current_enabled_status": "1",
+    "element_name": "Integrated NIC 1 Port 2 Partition 1: IBA XE Slot 0101 v2364 BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#NIC.Integrated.1-2-1#dc1013955817bf0f19cb88fe0ccb8763",
+    "pending_assigned_sequence": "4",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "Virtual Floppy Drive BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "Virtual Floppy Drive BootSeq",
+    "current_assigned_sequence": "5",
+    "current_enabled_status": "1",
+    "element_name": "Virtual Floppy Drive BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#Floppy.iDRACVirtual.1-1#d4f2481e04c9b4c4922e0b3072623208",
+    "pending_assigned_sequence": "5",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "NIC in Slot 1 Port 2 Partition 1: IBA XE Slot 8401 v2334 BootSeq",
+    "boot_source_type": "IPL",
+    "boot_string": "NIC in Slot 1 Port 2 Partition 1: IBA XE Slot 8401 v2334 BootSeq",
+    "current_assigned_sequence": "6",
+    "current_enabled_status": "1",
+    "element_name": "NIC in Slot 1 Port 2 Partition 1: IBA XE Slot 8401 v2334 BootSeq",
+    "fail_through_supported": "1",
+    "instance_id": "IPL:BIOS.Setup.1-1#BootSeq#NIC.Slot.1-2-1#7ce179818e656abf50886525906c7353",
+    "pending_assigned_sequence": "6",
+    "pending_enabled_status": "1"
+  },
+  {
+    "bios_boot_string": "Integrated Storage Controller 1: #0200 ID0A LUN0 TOSHIBA  PX04SHB040 HddSeq",
+    "boot_source_type": "BCV",
+    "boot_string": "Integrated Storage Controller 1: #0200 ID0A LUN0 TOSHIBA  PX04SHB040 HddSeq",
+    "current_assigned_sequence": "0",
+    "current_enabled_status": "1",
+    "element_name": "Integrated Storage Controller 1: #0200 ID0A LUN0 TOSHIBA  PX04SHB040 HddSeq",
+    "fail_through_supported": "2",
+    "instance_id": "BCV:BIOS.Setup.1-1#HddSeq#NonRAID.Integrated.1-1#68dd2d28ce3d8e4718e542e13b305780",
+    "pending_assigned_sequence": "0",
+    "pending_enabled_status": "1"
+  },
+  {
+      "bios_boot_string": "Embedded SATA Port Disk I: UB96PHS64H0CM1-DTE HddSeq",
+      "boot_source_type": "BCV",
+      "boot_string": "Embedded SATA Port Disk I: UB96PHS64H0CM1-DTE HddSeq",
+      "current_assigned_sequence": "0",
+      "current_enabled_status": "1",
+      "element_name": "Embedded SATA Port Disk I: UB96PHS64H0CM1-DTE HddSeq",
+      "fail_through_supported": "2",
+      "instance_id": "BCV:BIOS.Setup.1-1#HddSeq#Disk.SATAEmbedded.I-1#64ca3626d17be3ccae939f0cff7f7ec9",
+      "pending_assigned_sequence": "0",
+      "pending_enabled_status": "1"
+  }
+]

--- a/spec/unit/puppet/provider/importtemplatexml_spec.rb
+++ b/spec/unit/puppet/provider/importtemplatexml_spec.rb
@@ -639,8 +639,15 @@ describe Puppet::Provider::Importtemplatexml do
     let(:satadom_boot_sources_data) { JSON.parse(File.read(test_config_dir.path + '/satadom_boot_sources.json'), :symbolize_names=>true) }
 
     it "Should return SATDOM id if SATADOM present." do
-      Puppet::Idrac::Util.stub(:boot_source_settings).and_return(boot_sources_data)
-      #expect(@fixture.get_satadom).to eq("Disk.SATAEmbedded.J-1")
+      Puppet::Idrac::Util.stub(:boot_source_settings).and_return(satadom_boot_sources_data)
+      expect(@fixture.get_satadom).to eq("Disk.SATAEmbedded.J-1")
+    end
+
+    let(:satadom_boot_sources_1_data) { JSON.parse(File.read(test_config_dir.path + '/satadom_boot_sources_1.json'), :symbolize_names=>true) }
+
+    it "Should return SATDOM id if SATADOM present." do
+      Puppet::Idrac::Util.stub(:boot_source_settings).and_return(satadom_boot_sources_1_data)
+      expect(@fixture.get_satadom).to eq("Disk.SATAEmbedded.I-1")
     end
   end
 


### PR DESCRIPTION
Some new satadom were returning a different device string that did not contain the words /SATADOM/ and as such were unrecognized
