### PR TITLE
VXFM-9700 New orchstration flow to support whole Rack RCM update with downtime

### DIFF
--- a/lib/puppet/type/idrac_fw_installfromuri.rb
+++ b/lib/puppet/type/idrac_fw_installfromuri.rb
@@ -16,4 +16,19 @@ Puppet::Type.newtype(:idrac_fw_installfromuri) do
   newparam(:force_restart, :boolean => true, :parent => Puppet::Parameter::Boolean) do
     desc "Forces the restart now"
   end
+
+  newparam(:skip_clear_job_queue, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+    desc "Forces the restart now"
+    defaultto false
+  end
+
+  newparam(:disruptive_firmware_update, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+    desc "Disruptive firmware update"
+    defaultto false
+  end
+
+  newparam(:install_staged_firmware, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+    desc "Install staged firmware update"
+    defaultto false
+  end
 end


### PR DESCRIPTION
Support staging (downloading) of the firmware on all the nodes first. If this operation is successfull and proceed with rack firmware upgrade, In second stage need to schedule reboot job on the servers to have firmware applied