### PR TITLE
VXFM-10639 Disruptive firmware operation failed to install SAS firmware

### DIFF
--- a/lib/puppet/provider/idrac_fw_installfromuri/wsman.rb
+++ b/lib/puppet/provider/idrac_fw_installfromuri/wsman.rb
@@ -70,8 +70,9 @@ Puppet::Type.type(:idrac_fw_installfromuri).provide(
   def find_downloaded_firmware_job(firmware)
     downloaded_jobs.find do |j|
       j[:name] =~ /Firmware Update:\s+(\S+)/
+      match = $1
 
-      firmware["instance_id"] =~ /#{$1}/i
+      firmware["instance_id"] =~ /#{match}/i || firmware["uri_path"] =~ /#{match}/i
     end
   end
 


### PR DESCRIPTION
Failed to install SAS firmware as logic to map downloaded job from pre_firmware operation is not matching with the firmware list